### PR TITLE
fix: commit build-time env defaults so the app can build at all

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,13 @@
+# Committed build-time placeholders. NOT secrets.
+#
+# Auth.js validates provider config at MODULE CONSTRUCTION, so `next build`
+# fails while collecting page data for /api/auth/[...nextauth] when these are
+# unset — the app cannot be built at all without them.
+#
+# Real values live in Vercel and in .env.local, both of which override this
+# file. Next reads .env first, then .env.local on top.
+EMAIL_SERVER="smtp://user:pass@localhost:587"
+EMAIL_FROM="noreply@localhost"
+NEXTAUTH_URL="http://localhost:3000"
+AUTH_SECRET="build-placeholder-not-a-secret"
+NEXTAUTH_SECRET="build-placeholder-not-a-secret"

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ next-env.d.ts
 
 /src/generated/prisma
 !.env.example
+!.env


### PR DESCRIPTION
The assembled integration branch failed its build gate:

```
Failed to collect configuration for /api/auth/[...nextauth]
  cause: Nodemailer requires a `server` configuration.
```

Auth.js validates provider config at **module construction**. `next build` collects page data for the auth route, which imports `src/auth.ts`, which constructs the provider — so **the app cannot be built without these variables**, on any machine, including CI.

The earlier `vitest.setup.ts` fix covered tests only; the build has no such hook. This uses Next's own convention: a committed `.env` for non-secret defaults, with `.env.local` and Vercel's environment overriding it.

The values are deliberately obvious placeholders — nothing here is a secret, and nothing here works (the SMTP host is `localhost`). Real credentials live in Vercel, which is also the only place magic-link will actually send mail.

**Verified against the integration branch's own code:** build compiles, 12 tests pass, `tsc` clean, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgUuHL6M6pBwuwozBPFph3