### PR TITLE
feat(#38): Story 8 — Build the coach prompt

### DIFF
--- a/src/lib/coach/prompt.test.ts
+++ b/src/lib/coach/prompt.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest'
+import { buildCoachPrompt } from './prompt'
+import type { ProfileContext } from '@/lib/profile/context'
+
+describe('prompt', () => {
+  const base: ProfileContext = {
+    name: 'Ada',
+    likes: [],
+    dislikes: [],
+    jokes: [],
+    dreams: [],
+    recentMoods: [],
+    recentEvents: [],
+    pastGifts: [],
+    pastTrips: []
+  }
+
+  it('includes the partner name', () => {
+    const prompt = buildCoachPrompt(base, [], 'hello')
+    expect(prompt).toContain('Ada')
+  })
+
+  it('includes populated sections', () => {
+    const prompt = buildCC({ ...base, likes: ['tea', 'coffee'] }, [], 'hello')
+    expect(prompt).toContain('Likes:')
+    expect(prompt).toContain('tea')
+    expect(prompt).toContain('coffee')
+  })
+
+  it('omits empty sections', () => {
+    const prompt = buildCoachPrompt(base, [], 'hello')
+    expect(prompt).not.toContain('Dislikes:')
+    expect(prompt).not.toContain('Jokes:')
+    expect(prompt).not.toContain('Dreams:')
+  })
+
+  it('ends with the user message', () => {
+    const userMsg = 'what should I plan?'
+    const prompt = buildCoachPrompt(base, [{ role: 'user', text: 'hi' }], userMsg)
+    expect(prompt.endsWith(userMsg)).toBe(true)
+  })
+})
+
+/**
+ * Helper to avoid repetitive spreading in tests while keeping the logic clean
+ * though the prompt asks to use spread in the tests themselves, 
+ * I'll use the spread pattern directly in the tests as requested.
+ */
+function buildCC(ctx: ProfileContext, hist: any[], msg: string) {
+  return buildCoachPrompt(ctx, hist, msg)
+}

--- a/src/lib/coach/prompt.ts
+++ b/src/lib/coach/prompt.ts
@@ -1,0 +1,58 @@
+import type { ProfileContext } from '@/lib/profile/context';
+
+export function buildCoachPrompt(
+  context: ProfileContext,
+  history: { role: string; text: string }[],
+  userMessage: string
+): string {
+  const sections: string[] = [];
+
+  if (context.likes.length > 0) {
+    sections.push(`Likes: ${context.likes.join(', ')}`);
+  }
+  if (context.dislikes.length > 0) {
+    sections.push(`Dislikes: ${context.dislikes.join(', ')}`);
+  }
+  if (context.jokes.length > 0) {
+    sections.push(`Jokes: ${context.jokes.join(', ')}`);
+  }
+  if (context.dreams.length > 0) {
+    sections.push(`Dreams: ${context.dreams.join(', ')}`);
+  }
+  if (context.recentMoods.length > 0) {
+    const moods = context.recentMoods
+      .map((m) => `${m.label}${m.note ? ': ' + m.note : ''}`)
+      .join(', ');
+    sections.push(`Recent moods: ${moods}`);
+  }
+  if (context.recentEvents.length > 0) {
+    const events = context.recentEvents
+      .map((e) => `${e.title}${e.note ? ': ' + e.note : ''}`)
+      .join(', ');
+    sections.push(`Recent events: ${events}`);
+  }
+  if (context.pastGifts.length > 0) {
+    sections.push(`Past gifts: ${context.pastGifts.join(', ')}`);
+  }
+  if (context.pastTrips.length > 0) {
+    sections.push(`Past trips: ${context.pastTrips.join(', ')}`);
+  }
+
+  const contextString = sections.length > 0 ? sections.join('\n') : '';
+
+  let prompt = `You are a relationship coach. Your job is to help the user understand and delight their partner, ${context.name}, using only the information provided in the profile records below.\n\n`;
+
+  if (contextString) {
+    prompt += `${contextString}\n\n`;
+  }
+
+  prompt += 'Do not invent facts about the partner that are absent from the context.\n\n';
+
+  for (const entry of history) {
+    prompt += `${entry.role}: ${entry.text}\n`;
+  }
+
+  prompt += `\nUser: ${userMessage}`;
+
+  return prompt;
+}


### PR DESCRIPTION
## Summary

Implements story #38: Story 8 — Build the coach prompt

## Verified gates (auto-captured by dag-poc)

- `smoke` exit 0
- `typecheck` exit 0
- `lint` exit 0

## Implementation provenance

- Model: `spike-coder-v3:latest` (local Ollama)
- LLM calls: 3
- Prompt tokens: 22969
- Output tokens: 2377

Closes #38

Co-Authored-By: gemma4:26b (Spike coder) <noreply@spike.local>

## Verified gates *(auto-captured by spike-guard)*

- build: ✓ exit 0 (run at 2026-08-17T22:06:55Z)
- lint: ✓ exit 0 (run at 2026-08-17T22:07:12Z)
- test: ✓ exit 0 (run at 2026-08-17T22:06:51Z)
