### PR TITLE
Epic 2 — Telegram coach: webhook, questionnaire, conversation loop, cadences

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@ AI_PROVIDER="ollama"
 OLLAMA_BASE_URL="http://localhost:11434"
 # Ollama model name
 OLLAMA_MODEL="gemma4:26"
-# Anthropic API key (set AI_PROVIDER=anthropic to use)
+# Anthropic API key (set AI_PROVIDER=webhook to use)
 # ANTHROPIC_API_KEY=""
 # Anthropic model override
 # ANTHROPIC_MODEL="claude-sonnet-4-5"
@@ -17,3 +17,9 @@ NEXTAUTH_URL="http://localhost:3000"
 # Magic-link email transport (SMTP URL format)
 EMAIL_SERVER="smtp://user:pass@smtp.example.com:587"
 EMAIL_FROM="noreply@example.com"
+# Telegram Bot Token (obtained from @BotFather)
+# TELEGRAM_BOT_TOKEN=""
+# Telegram Webhook Secret (a value you choose and pass to setWebhook)
+# TELEGRAM_WEBHOOK_SECRET=""
+# Cron Secret (a value you set in Vercel for the cron job)
+# CRON_SECRET=""

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,6 +27,11 @@ model Profile {
   trips        Trip[]
   dreams       Dream[]
   suggestions  Suggestion[]
+  telegramChats TelegramChat[]
+  messages     Message[]
+  questionnaireAnswers QuestionnaireAnswer[]
+  occasions    Occasion[]
+  cadenceRuns  CadenceRun[]
 }
 
 model LikesEntry {
@@ -105,8 +110,60 @@ model Suggestion {
   profileId String
   body      String
   audience  String   @default("private")
+  kind      String   @default("date")
   createdAt DateTime @default(now())
   profile   Profile  @relation(fields: [profileId], references: [id], onDelete: Cascade)
+}
+
+model TelegramChat {
+  id        String   @id @default(cuid())
+  chatId    String   @unique
+  profileId String
+  createdAt DateTime @default(now())
+  profile   Profile  @relation(fields: [profileId], references: [id], onDelete: Cascade)
+}
+
+model Message {
+  id        String   @id @default(cuid())
+  profileId String
+  role      String
+  text      String
+  createdAt DateTime @default(now())
+  profile   Profile  @relation(fields: [profileId], references: [id], onDelete: Cascade)
+}
+
+model QuestionnaireAnswer {
+  id        String   @id @default(cuid())
+  profileId String
+  questionId String
+  answer    String
+  createdAt DateTime @default(now())
+  profile   Profile  @relation(fields: [profileId], references: [id], onDelete: Cascade)
+
+  @@unique([profileId, questionId])
+}
+
+model Occasion {
+  id           String   @id @default(cuid())
+  profileId    String
+  kind         String
+  label        String
+  month        Int
+  day          Int
+  leadTimeDays Int      @default(7)
+  createdAt    DateTime @default(now())
+  profile      Profile  @relation(fields: [profileId], references: [id], onDelete: Cascade)
+}
+
+model CadenceRun {
+  id        String   @id @default(cuid())
+  profileId String
+  kind      String
+  ranOn     DateTime
+  createdAt DateTime @default(now())
+  profile   Profile  @relation(fields: [profileId], references: [id], onDelete: Cascade)
+
+  @@unique([profileId, kind, ranOn])
 }
 
 model User {

--- a/src/app/api/cron/route.test.ts
+++ b/src/app/api/cron/route.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { prisma } from '@/lib/db'
+import { respond } from '@/lib/coach/respond'
+import { sendMessage } from '@/lib/telegram/send'
+import { GET } from './route'
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    telegramChat: { findMany: vi.fn() },
+    occasion: { findMany: vi.fn() },
+    cadenceRun: { findFirst: vi.fn(), create: vi.fn() },
+  },
+}))
+vi.mock('@/lib/coach/respond', () => ({ respond: vi.fn() }))
+vi.mock('@/lib/telegram/send', () => ({ sendMessage: vi.fn() }))
+// @/lib/cadence/due and @/lib/cadence/occasions are NOT mocked: they are pure
+// local modules, and mocking them would assert against our own mock.
+
+function request(auth?: string): Request {
+  return new Request('http://localhost/api/cron',
+    auth ? { headers: { authorization: auth } } : undefined)
+}
+
+describe('GET /api/cron', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env.CRON_SECRET = 'cronsecret'
+    vi.mocked(prisma.telegramChat.findMany).mockResolvedValue([
+      { chatId: '42', profileId: 'p1' },
+    ] as never)
+    vi.mocked(prisma.occasion.findMany).mockResolvedValue([] as never)
+    vi.mocked(prisma.cadenceRun.findFirst).mockResolvedValue(null)
+    vi.mocked(prisma.cadenceRun.create).mockResolvedValue({} as never)
+    vi.mocked(respond).mockResolvedValue('good morning')
+  })
+
+  it('rejects a request without the cron secret', async () => {
+    const res = await GET(request())
+
+    expect(res.status).toBe(401)
+    expect(sendMessage).not.toHaveBeenCalled()
+  })
+
+  it('rejects everything when the secret is unconfigured', async () => {
+    delete process.env.CRON_SECRET
+
+    const res = await GET(request('Bearer anything'))
+
+    expect(res.status).toBe(401)
+  })
+
+  it('sends the daily check-in', async () => {
+    const res = await GET(request('Bearer cronsecret'))
+
+    expect(res.status).toBe(200)
+    expect(sendMessage).toHaveBeenCalledWith('42', 'good morning')
+    expect(prisma.cadenceRun.create).toHaveBeenCalled()
+  })
+
+  it('does not resend a cadence already run today', async () => {
+    vi.mocked(prisma.cadenceRun.findFirst).mockResolvedValue({ id: 'r1' } as never)
+
+    await GET(request('Bearer cronsecret'))
+
+    expect(sendMessage).not.toHaveBeenCalled()
+  })
+
+  it('reports the number of messages sent', async () => {
+    const res = await GET(request('Bearer cronsecret'))
+
+    const body = await res.json()
+    expect(typeof body.sent).toBe('number')
+    expect(body.sent).toBeGreaterThan(0)
+  })
+})

--- a/src/app/api/cron/route.ts
+++ b/src/app/api/cron/route.ts
@@ -1,0 +1,61 @@
+import { prisma } from '@/lib/db'
+import { respond } from '@/lib/coach/respond'
+import { sendMessage } from '@/lib/telegram/send'
+import { dueCadences, type CadenceKind } from '@/lib/cadence/due'
+import { dueOccasions } from '@/lib/cadence/occasions'
+
+const OPENERS: Record<CadenceKind, string> = {
+  daily: 'Daily check-in: how are things going today, and what did you notice?',
+  weekly: 'Weekly session: looking back over the week, what stood out?',
+  monthly: 'Monthly session: how has this month been for the two of you?',
+}
+
+export async function GET(request: Request): Promise<Response> {
+  const secret = process.env.CRON_SECRET
+  if (!secret || request.headers.get('authorization') !== `Bearer ${secret}`) {
+    return Response.json({ ok: false }, { status: 401 })
+  }
+
+  const today = new Date()
+  // UTC midnight, so the once-per-day guard keys on the date, not the moment.
+  const ranOn = new Date(Date.UTC(
+    today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate()))
+  const kinds = dueCadences(today)
+
+  let sent = 0
+  const chats = await prisma.telegramChat.findMany()
+  for (const chat of chats) {
+    for (const kind of kinds) {
+      const already = await prisma.cadenceRun.findFirst({
+        where: { profileId: chat.profileId, kind, ranOn },
+      })
+      if (already) continue
+      const reply = await respond(chat.profileId, OPENERS[kind])
+      await sendMessage(chat.chatId, reply)
+      await prisma.cadenceRun.create({
+        data: { profileId: chat.profileId, kind, ranOn },
+      })
+      sent += 1
+    }
+
+    const occasions = await prisma.occasion.findMany({
+      where: { profileId: chat.profileId },
+    })
+    for (const occasion of dueOccasions(occasions, today)) {
+      const days = Math.ceil(
+        (Date.UTC(
+          occasion.month - 1 < today.getUTCMonth()
+          || (occasion.month - 1 === today.getUTCMonth()
+              && occasion.day < today.getUTCDate())
+            ? today.getUTCFullYear() + 1 : today.getUTCFullYear(),
+          occasion.month - 1, occasion.day) - ranOn.getTime())
+        / (24 * 60 * 60 * 1000))
+      await sendMessage(
+        chat.chatId,
+        `Heads up: ${occasion.label} is ${days <= 0 ? 'today' : `in ${days} day${days === 1 ? '' : 's'}`}.`)
+      sent += 1
+    }
+  }
+
+  return Response.json({ ok: true, sent })
+}

--- a/src/app/api/telegram/route.test.ts
+++ b/src/app/api/telegram/route.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { prisma } from '@/lib/db'
+import type { TelegramChat } from '@prisma/client'
+import { POST } from './route'
+import { sendMessage } from '@/lib/telegram/send'
+import { respond } from '@/lib/coach/respond'
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    profile: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    likesEntry: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    dislikesEntry: { create: vi.fn(), createMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    joke: { create: vi.fn(), createMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    mood: { create: vi.fn(), createMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    event: { create: vi.fn(), createMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    gift: { create: vi.fn(), createMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    trip: { create: vi.fn(), createMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    dream: { create: vi.fn(), createMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    suggestion: { create: vi.fn(), createMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    telegramChat: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    message: { create: vi.fn(), createMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    questionnaireAnswer: { create: vi.fn(), createMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    occasion: { create: vi.fn(), createMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    cadenceRun: { create: vi.fn(), createMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    user: { create: vi.fn(), createMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    account: { create: vi.fn(), createMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    session: { create: vi.fn(), createMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    verificationToken: { create: vi.fn(), createMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+  },
+}))
+
+vi.mock('@/lib/telegram/send', () => ({
+  sendMessage: vi.fn(),
+}))
+
+vi.mock('@/lib/coach/respond', () => ({
+  respond: vi.fn(),
+}))
+
+const makeTelegramChat = (overrides: Partial<TelegramChat> = {}): TelegramChat =>
+  ({
+    id: '',
+    chatId: '',
+    profileId: '',
+    createdAt: new Date(Date.UTC(2024, 0, 1)),
+    ...overrides,
+  } as unknown as TelegramChat)
+
+describe('route', () => {
+  const WEBHOOK_SECRET = 'super-secret-token'
+  const VALID_HEADER = 'valid-token'
+  const INVALID_HEADER = 'wrong-token'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env.TELEGRAM_WEBHOOK_SECRET = WEBHOOK_SECRET
+  })
+
+  it('rejects a request with the wrong secret', async () => {
+    const request = new Request('https://api.telegram.org/webhook', {
+      method: 'POST',
+      headers: {
+        'x-telegram-bot-api-secret-token': INVALID_HEADER,
+      },
+    })
+
+    const response = await POST(request)
+    expect(response.status).toBe(401)
+    expect(respond).not.toHaveBeenCalled()
+  })
+
+  it('acknowledges a non-text update', async () => {
+    // We use a payload that parseUpdate will return null for (e.g. an unhandled update type)
+    // Since parseUpdate is not mocked, we rely on its real behavior. 
+    // For this test, we provide a valid JSON that doesn't contain a message.text
+    const request = new Request('https://api.telegram.im/webhook', {
+      method: 'POST',
+      headers: {
+        'x-telegram-bot-api-secret-token': WEBHOOK_SECRET,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        update_id: 12345,
+        // No message object, so parseUpdate should return null
+      }),
+    })
+
+    const response = await POST(request)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body).toEqual({ ok: true })
+    expect(respond).not.toHaveBeenCalled()
+  })
+
+  it('replies to a known chat', async () => {
+    const chatId = '12345'
+    const text = 'Hello Coach!'
+    const profileId = 'p1'
+    const replyText = 'Hello back!'
+
+    const request = new Request('https://api.telegram.org/webhook', {
+      method: 'POST',
+      headers: {
+        'x-telegram-bot-api-secret-token': WEBHOOK_SECRET,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        message: {
+          chat: { id: chatId },
+          text: text,
+        },
+      }),
+    })
+
+    vi.mocked(prisma.telegramChat.findUnique).mockResolvedValue(makeTelegramChat({ chatId, profileId }))
+    vi.mocked(respond).mockResolvedValue(replyText)
+
+    const response = await POST(request)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body).toEqual({ ok: true })
+    expect(respond).toHaveBeenCalledWith(profileId, text)
+    expect(sendMessage).toHaveBeenCalledWith(chatId, replyText)
+  })
+
+  it('prompts an unknown chat to link', async () => {
+    const chatId = '99999'
+    const text = 'Hi'
+
+    const request = new Request('https://api.telegram.org/webhook', {
+      method: 'POST',
+  		headers: {
+  			'x-telegram-bot-api-secret-token': WEBHOOK_SECRET,
+  			'Content-Type': 'application/json',
+  		},
+  		body: JSON.stringify({
+  			message: {
+  				chat: { id: chatId },
+  				text: text,
+  			},
+  		}),
+    })
+
+    vi.mocked(prisma.telegramChat.findUnique).mockResolvedValue(null)
+
+    const response = await POST(request)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body).toEqual({ ok: true })
+    expect(respond).not.toHaveBeenCalled()
+    expect(sendMessage).toHaveBeenCalledWith(chatId, "Please link your Telegram account to use this bot.")
+  })
+})

--- a/src/app/api/telegram/route.ts
+++ b/src/app/api/telegram/route.ts
@@ -1,0 +1,46 @@
+import { verifyTelegramSecret } from '@/lib/telegram/verify';
+import { parseUpdate } from '@/lib/telegram/parse';
+import { sendMessage } from '@/lib/telegram/send';
+import { respond } from '@/lib/coach/respond';
+import { prisma } from '@/lib/db';
+
+export async function POST(request: Request): Promise<Response> {
+  const secretToken = request.headers.get('x-telegram-bot-api-secret-token');
+  const webhookSecret = process.env.TELEGRAM_WEBHOOK_SECRET;
+
+  if (!secretToken || !webhookSecret || !(await verifyTelegramSecret(secretToken, webhookSecret))) {
+    return new Response(null, { status: 401 });
+  }
+
+  let update;
+  try {
+    update = await request.json();
+  } catch (err) {
+    return new Response(null, { status: 400 });
+  }
+
+  const parsed = parseUpdate(update);
+  if (!parsed) {
+    return new Response(JSON.stringify({ ok: true }), { status: 200 });
+  }
+
+  const { chatId, text } = parsed;
+
+  if (!text) {
+    return new Response(JSON.stringify({ ok: true }), { status: 200 });
+  }
+
+  const chat = await prisma.telegramChat.findUnique({
+    where: { chatId },
+  });
+
+  if (!chat) {
+    await sendMessage(chatId, "Please link your Telegram account to use this bot.");
+    return new Response(JSON.stringify({ ok: true }), { status: 200 });
+  }
+
+  const replyText = await respond(chat.profileId, text);
+  await sendMessage(chatId, replyText);
+
+  return new Response(JSON.stringify({ ok: true }), { status: 200 });
+}

--- a/src/lib/cadence/due.test.ts
+++ b/src/lib/cadence/due.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest'
+import { dueCadences } from './due'
+
+describe('due', () => {
+  it('a plain weekday is daily only', () => {
+    // 2026-08-18 is a Tuesday
+    const date = new Date(Date.UTC(2026, 7, 18, 9, 0, 0))
+    expect(dueCadences(date)).toEqual(['daily'])
+  })
+
+  it('Sunday adds weekly', () => {
+    // 2026-08-23 is a Sunday
+    const date = new Date(Date.UTC(2026, 7, 23, 9, 0, 0))
+    expect(dueCadences(date)).toEqual(['daily', 'weekly'])
+  })
+
+  it('the first of the month adds monthly', () => {
+    // 2026-09-01 is a Tuesday
+    const date = new Date(Date.UTC(2026, 8, 1, 9, 0, 0))
+    expect(dueCadences(date)).toEqual(['daily', 'monthly'])
+  })
+
+  it('a Sunday the first returns all three', () => {
+    // 2026-11-01 is a Sunday
+    const date = new Date(Date.UTC(2026, 10, 1, 9, 0, 0))
+    expect(dueCadences(date)).toEqual(['daily', 'weekly', 'monthly'])
+  })
+})

--- a/src/lib/cadence/due.ts
+++ b/src/lib/cadence/due.ts
@@ -1,0 +1,15 @@
+export type CadenceKind = 'daily' | 'weekly' | 'monthly';
+
+export function dueCadences(today: Date): CadenceKind[] {
+  const cadences: CadenceKind[] = ['daily'];
+
+  if (today.getUTCDay() === 0) {
+    cadences.push('weekly');
+  }
+
+  if (today.getUTCDate() === 1) {
+    cadences.push('monthly');
+  }
+
+  return cadences;
+}

--- a/src/lib/cadence/occasions.test.ts
+++ b/src/lib/cadence/occasions.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import { dueOccasions, type OccasionInput } from './occasions'
+
+describe('occasions', () => {
+  it('an occasion inside the lead window is due', () => {
+    const today = new Date(Date.UTC(2026, 7, 17)) // 2026-08-17
+    const occasions: OccasionInput[] = [
+      {
+        id: '1',
+        kind: 'birthday',
+        label: 'Alice',
+        month: 8,
+        day: 20,
+        leadTimeDays: 7,
+      },
+    ]
+    // 20 Aug is within 7 days of 17 Aug (17, 18, 19, 20, 21, 22, 23)
+    const result = dueOccasions(occasions, today)
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe('1')
+  })
+
+  it('an occasion beyond the lead window is not due', () => {
+    const today = new Date(Date.UTC(2026, 7, 1)) // 2026-08-01
+    const occasions: OccasionInput[] = [
+      {
+        id: '1',
+        kind: 'birthday',
+        label: 'Alice',
+        month: 8,
+        day: 20,
+        leadTimeDays: 7,
+      },
+    ]
+    // 20 Aug is far beyond 1 Aug + 7 days
+    const result = dueOccasions(occasions, today)
+    expect(result).toHaveLength(0)
+  })
+
+  it('an occasion today is due', () => {
+    const today = new Date(Date.UTC(2026, 7, 17)) // 2026-08-17
+    const occasions: OccasionInput[] = [
+      {
+        id: '1',
+        kind: 'birthday',
+        label: 'Alice',
+        month: 8,
+        day: 17,
+        leadTimeDays: 7,
+      },
+    ]
+    const result = dueOccasions(occasions, today)
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe('1')
+  })
+
+  it('a passed occasion rolls to next year', () => {
+    const today = new Date(Date.UTC(2026, 11, 27)) // 2026-12-27
+    const occasions: OccasionInput[] = [
+      {
+        id: '1',
+        kind: 'birthday',
+        label: 'Alice',
+        month: 1,
+        day: 3,
+        leadTimeDays: 14,
+      },
+    ]
+    // 3 Jan 2027 is within 14 days of 27 Dec 2026
+    const result = dueOccasions(occasions, today)
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe('1')
+  })
+
+  it('returns empty when nothing is approaching', () => {
+    const today = new Date(Date.UTC(2026, 0, 1))
+    const occasions: OccasionInput[] = []
+    const result = dueOccasions(occasions, today)
+    expect(result).toEqual([])
+  })
+})

--- a/src/lib/cadence/occasions.ts
+++ b/src/lib/cadence/occasions.ts
@@ -1,0 +1,38 @@
+export type OccasionInput = {
+  id: string;
+  kind: string;
+  label: string;
+  month: number;
+  day: number;
+  leadTimeDays: number;
+};
+
+export function dueOccasions(occasions: OccasionInput[], today: Date): OccasionInput[] {
+  const results: OccasionInput[] = [];
+  const todayStart = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+
+  for (const occasion of occasions) {
+    // 1. Start with the occurrence in the current year
+    let occurrence = new Date(today.getFullYear(), occasion.month - 1, occasion.day);
+    let occurrenceStart = new Date(occurrence.getFullYear(), occurrence.getMonth(), occurrence.getDate());
+
+    // 2. If the date has already passed this year, roll to next year
+    if (occurrenceStart < todayStart) {
+      const nextYear = occurrence.getFullYear() + 1;
+      occurrence = new Date(nextYear, occasion.month - 1, occasion.day);
+      occurrenceStart = new Date(occurrence.getFullYear(), occurrence.getMonth(), occurrence.getDate());
+    }
+
+    // 3. Calculate the end of the lead window (today + leadTimeDays)
+    const windowEnd = new Date(todayStart);
+    windowEnd.setDate(todayStart.getDate() + occasion.leadTimeDays);
+    const windowEndEndOfDay = new Date(windowEnd.getFullYear(), windowEnd.getMonth(), windowEnd.getDate(), 23, 59, 59, 999);
+
+    // 4. Check if the occurrence falls within [today, today + leadTimeDays]
+    if (occurrenceStart >= todayStart && occurrenceStart <= windowEndEndOfDay) {
+      results.push(occasion);
+    }
+  }
+
+  return results;
+}

--- a/src/lib/coach/prompt.test.ts
+++ b/src/lib/coach/prompt.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest'
+import { buildCoachPrompt } from './prompt'
+import type { ProfileContext } from '@/lib/profile/context'
+
+describe('prompt', () => {
+  const base: ProfileContext = {
+    name: 'Ada',
+    likes: [],
+    dislikes: [],
+    jokes: [],
+    dreams: [],
+    recentMoods: [],
+    recentEvents: [],
+    pastGifts: [],
+    pastTrips: []
+  }
+
+  it('includes the partner name', () => {
+    const prompt = buildCoachPrompt(base, [], 'hello')
+    expect(prompt).toContain('Ada')
+  })
+
+  it('includes populated sections', () => {
+    const prompt = buildCC({ ...base, likes: ['tea', 'coffee'] }, [], 'hello')
+    expect(prompt).toContain('Likes:')
+    expect(prompt).toContain('tea')
+    expect(prompt).toContain('coffee')
+  })
+
+  it('omits empty sections', () => {
+    const prompt = buildCoachPrompt(base, [], 'hello')
+    expect(prompt).not.toContain('Dislikes:')
+    expect(prompt).not.toContain('Jokes:')
+    expect(prompt).not.toContain('Dreams:')
+  })
+
+  it('ends with the user message', () => {
+    const userMsg = 'what should I plan?'
+    const prompt = buildCoachPrompt(base, [{ role: 'user', text: 'hi' }], userMsg)
+    expect(prompt.endsWith(userMsg)).toBe(true)
+  })
+})
+
+/**
+ * Helper to avoid repetitive spreading in tests while keeping the logic clean
+ * though the prompt asks to use spread in the tests themselves, 
+ * I'll use the spread pattern directly in the tests as requested.
+ */
+function buildCC(ctx: ProfileContext, hist: any[], msg: string) {
+  return buildCoachPrompt(ctx, hist, msg)
+}

--- a/src/lib/coach/prompt.ts
+++ b/src/lib/coach/prompt.ts
@@ -1,0 +1,58 @@
+import type { ProfileContext } from '@/lib/profile/context';
+
+export function buildCoachPrompt(
+  context: ProfileContext,
+  history: { role: string; text: string }[],
+  userMessage: string
+): string {
+  const sections: string[] = [];
+
+  if (context.likes.length > 0) {
+    sections.push(`Likes: ${context.likes.join(', ')}`);
+  }
+  if (context.dislikes.length > 0) {
+    sections.push(`Dislikes: ${context.dislikes.join(', ')}`);
+  }
+  if (context.jokes.length > 0) {
+    sections.push(`Jokes: ${context.jokes.join(', ')}`);
+  }
+  if (context.dreams.length > 0) {
+    sections.push(`Dreams: ${context.dreams.join(', ')}`);
+  }
+  if (context.recentMoods.length > 0) {
+    const moods = context.recentMoods
+      .map((m) => `${m.label}${m.note ? ': ' + m.note : ''}`)
+      .join(', ');
+    sections.push(`Recent moods: ${moods}`);
+  }
+  if (context.recentEvents.length > 0) {
+    const events = context.recentEvents
+      .map((e) => `${e.title}${e.note ? ': ' + e.note : ''}`)
+      .join(', ');
+    sections.push(`Recent events: ${events}`);
+  }
+  if (context.pastGifts.length > 0) {
+    sections.push(`Past gifts: ${context.pastGifts.join(', ')}`);
+  }
+  if (context.pastTrips.length > 0) {
+    sections.push(`Past trips: ${context.pastTrips.join(', ')}`);
+  }
+
+  const contextString = sections.length > 0 ? sections.join('\n') : '';
+
+  let prompt = `You are a relationship coach. Your job is to help the user understand and delight their partner, ${context.name}, using only the information provided in the profile records below.\n\n`;
+
+  if (contextString) {
+    prompt += `${contextString}\n\n`;
+  }
+
+  prompt += 'Do not invent facts about the partner that are absent from the context.\n\n';
+
+  for (const entry of history) {
+    prompt += `${entry.role}: ${entry.text}\n`;
+  }
+
+  prompt += `\nUser: ${userMessage}`;
+
+  return prompt;
+}

--- a/src/lib/coach/respond.test.ts
+++ b/src/lib/coach/respond.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { prisma } from '@/lib/db'
+import { generate } from '@/lib/ai'
+import { getProfileContext, type ProfileContext } from '@/lib/profile/context'
+import { respond } from './respond'
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    message: { findMany: vi.fn(), create: vi.fn() },
+  },
+}))
+vi.mock('@/lib/ai', () => ({ generate: vi.fn() }))
+vi.mock('@/lib/profile/context', () => ({ getProfileContext: vi.fn() }))
+// @/lib/coach/prompt is NOT mocked: it is pure local code, and mocking it
+// would make these tests pass regardless of what the prompt builder does.
+
+const base: ProfileContext = {
+  name: 'Ada',
+  likes: [],
+  dislikes: [],
+  jokes: [],
+  dreams: [],
+  recentMoods: [],
+  recentEvents: [],
+  pastGifts: [],
+  pastTrips: [],
+}
+
+describe('respond', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(getProfileContext).mockResolvedValue(base)
+    vi.mocked(prisma.message.findMany).mockResolvedValue([] as never)
+    vi.mocked(prisma.message.create).mockResolvedValue({} as never)
+    vi.mocked(generate).mockResolvedValue('a thoughtful reply')
+  })
+
+  it('returns the generated reply', async () => {
+    await expect(respond('p1', 'hi')).resolves.toBe('a thoughtful reply')
+  })
+
+  it('persists both turns', async () => {
+    await respond('p1', 'hi')
+
+    expect(prisma.message.create).toHaveBeenCalledTimes(2)
+    expect(prisma.message.create).toHaveBeenCalledWith({
+      data: { profileId: 'p1', role: 'user', text: 'hi' },
+    })
+    expect(prisma.message.create).toHaveBeenCalledWith({
+      data: { profileId: 'p1', role: 'assistant', text: 'a thoughtful reply' },
+    })
+  })
+
+  it('handles a missing profile', async () => {
+    vi.mocked(getProfileContext).mockResolvedValue(null)
+
+    const reply = await respond('p1', 'hi')
+
+    expect(reply).toContain('profile')
+    expect(generate).not.toHaveBeenCalled()
+  })
+
+  it('passes recent history to the prompt', async () => {
+    vi.mocked(prisma.message.findMany).mockResolvedValue([
+      { role: 'assistant', text: 'second' },
+      { role: 'user', text: 'first' },
+    ] as never)
+
+    await respond('p1', 'and now?')
+
+    expect(generate).toHaveBeenCalledOnce()
+    expect(generate).toHaveBeenCalledWith(expect.stringContaining('first'))
+    expect(generate).toHaveBeenCalledWith(expect.stringContaining('second'))
+    // findMany returns newest-first; the prompt must read chronologically.
+    const prompt = vi.mocked(generate).mock.lastCall?.[0] ?? ''
+    expect(prompt.indexOf('first')).toBeLessThan(prompt.indexOf('second'))
+  })
+})

--- a/src/lib/coach/respond.ts
+++ b/src/lib/coach/respond.ts
@@ -1,0 +1,35 @@
+import { prisma } from '@/lib/db'
+import { generate } from '@/lib/ai'
+import { getProfileContext } from '@/lib/profile/context'
+import { buildCoachPrompt } from '@/lib/coach/prompt'
+
+export async function respond(
+  profileId: string,
+  userMessage: string
+): Promise<string> {
+  const context = await getProfileContext(profileId)
+  if (!context) {
+    return 'I do not have a profile set up yet.'
+  }
+
+  // Newest-first from the store, chronological for the prompt.
+  const recent = await prisma.message.findMany({
+    where: { profileId },
+    orderBy: { createdAt: 'desc' },
+    take: 20,
+  })
+  const history = [...recent]
+    .reverse()
+    .map((m) => ({ role: m.role, text: m.text }))
+
+  const reply = await generate(buildCoachPrompt(context, history, userMessage))
+
+  await prisma.message.create({
+    data: { profileId, role: 'user', text: userMessage },
+  })
+  await prisma.message.create({
+    data: { profileId, role: 'assistant', text: reply },
+  })
+
+  return reply
+}

--- a/src/lib/profile/context.test.ts
+++ b/src/lib/profile/context.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { getProfileContext } from './context'
+import { prisma as db } from '@/lib/db'
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    profile: {
+      findUnique: vi.fn(),
+    },
+  },
+}))
+
+describe('context', () => {
+  beforeEach(() => {
+    vi.mocked(db.profile.findUnique).mockClear()
+  })
+
+  it('returns null for an unknown profile', async () => {
+    vi.mocked(db.profile.findUnique).mockResolvedValue(null)
+
+    const result = await getProfileContext('unknown-id')
+
+    expect(result).toBeNull()
+  })
+
+  it('maps relations to plain strings', async () => {
+    const mockProfile = {
+      id: 'profile-1',
+      name: 'Ada',
+      likes: [{ text: 'tea' }],
+      dislikes: [{ text: 'coffee' }],
+      jokes: [{ text: 'dad joke' }],
+      dreams: [{ description: 'fly' }],
+      gifts: [{ description: 'book' }],
+      trips: [{ destination: 'Kyoto' }],
+      moods: [{ label: 'Happy', note: 'sunny day', recordedAt: new Date(Date.UTC(2023, 1, 1)) }],
+      events: [{ title: 'Birthday', note: 'big party', occurredAt: new Date(Date.UTC(2023, 1, 1)) }],
+      // Add required fields for the mock to be valid for the mapper
+      createdAt: new Date(0),
+      updatedAt: new Date(0),
+    }
+
+    vi.mocked(db.profile.findUnique).mockResolvedValue(mockProfile as any)
+
+    const result = await getProfileContext('profile-1')
+
+    expect(result).not.toBeNull()
+    if (result) {
+      expect(result.name).toBe('Ada')
+      expect(result.likes).toEqual(['tea'])
+      expect(result.dislikes).toEqual(['coffee'])
+      expect(result.jokes).toEqual(['dad joke'])
+      expect(result.dreams).toEqual(['fly'])
+      expect(result.pastGifts).toEqual(['book'])
+      expect(result.pastTrips).toEqual(['Kyoto'])
+      expect(result.recentMoods).toEqual([{ label: 'Happy', note: 'sunny day' }])
+      expect(result.recentEvents).toEqual([{ title: 'Birthday', note: 'big party' }])
+    }
+  })
+
+  it('fetches everything in one query', async () => {
+    vi.mocked(db.profile.findUnique).mockResolvedValue(null)
+
+    await getProfileContext('profile-1')
+
+    expect(db.profile.findUnique).toHaveBeenCalledTimes(1)
+  })
+
+  it('limits moods and events to ten, newest first', async () => {
+    vi.mocked(db.profile.findUnique).mockResolvedValue(null)
+
+    await getProfileContext('profile-1')
+
+    const callArgs = vi.mocked(db.profile.findUnique).mock.calls[0][0]
+    const include = callArgs.include
+
+    expect(include).toBeDefined()
+    // We use type assertion here because the mock return type is generic
+    const actualInclude = include as any
+
+    expect(actualInclude.moods).toEqual({
+      orderBy: { recordedAt: 'desc' },
+      take: 10,
+    })
+    expect(actualInclude.events).toEqual({
+      orderBy: { occurredAt: 'desc' },
+      take: 10,
+    })
+  })
+})

--- a/src/lib/profile/context.ts
+++ b/src/lib/profile/context.ts
@@ -1,0 +1,57 @@
+import { prisma } from "@/lib/db";
+
+export type ProfileContext = {
+  name: string;
+  likes: string[];
+  dislikes: string[];
+  jokes: string[];
+  dreams: string[];
+  recentMoods: { label: string; note: string | null }[];
+  recentEvents: { title: string; note: string | null }[];
+  pastGifts: string[];
+  pastTrips: string[];
+};
+
+export async function getProfileContext(profileId: string): Promise<ProfileContext | null> {
+  const profile = await prisma.profile.findUnique({
+    where: { id: profileId },
+    include: {
+      likes: true,
+      dislikes: true,
+      jokes: true,
+      dreams: true,
+      gifts: true,
+      trips: true,
+      moods: {
+        orderBy: { recordedAt: "desc" },
+        take: 10,
+      },
+      events: {
+        orderBy: { occurredAt: "desc" },
+        take: 10,
+      },
+    },
+  });
+
+  if (!profile) {
+    return null;
+  }
+
+  return {
+    name: profile.name,
+    likes: profile.likes.map((l) => l.text),
+    dislikes: profile.dislikes.map((d) => d.text),
+    jokes: profile.jokes.map((j) => j.text),
+    dreams: profile.dreams.map((dr) => dr.description),
+    recentMoods: profile.moods.map((m) => ({
+      label: m.label,
+      note: m.note,
+    })),
+    recentEvents: profile.events.map((e) => ({
+      title: e.title,
+      note: e.note,
+    })),
+    pastGifts: profile.gifts.map((g) => g.description),
+    pastTrips: profile.trips.map((t) => t.destination),
+  };
+}

--- a/src/lib/questionnaire/flow.test.ts
+++ b/src/lib/questionnaire/flow.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import { nextQuestion } from './flow'
+import { QUESTIONS } from '@/lib/questionnaire/questions'
+
+describe('flow', () => {
+  it('returns the first question when nothing is answered', () => {
+    expect(nextQuestion([])).toEqual(QUESTIONS[0])
+  })
+
+  it('skips answered questions', () => {
+    const answeredIds = [QUESTIONS[0].id]
+    expect(nextQuestion(answeredIds)).toEqual(QUESTIONS[1])
+  })
+
+  it('returns null when all are answered', () => {
+    const allAnsweredIds = QUESTIONS.map((q) => q.id)
+    expect(nextQuestion(allAnsweredIds)).toBeNull()
+  })
+
+  it('unknown ids are ignored', () => {
+    const answeredIds = ['no-such-question']
+    expect(nextQuestion(answeredIds)).toEqual(QUESTIONS[0])
+  })
+})

--- a/src/lib/questionnaire/flow.ts
+++ b/src/lib/questionnaire/flow.ts
@@ -1,0 +1,13 @@
+import { QUESTIONS, type Question } from '@/lib/questionnaire/questions';
+
+/**
+ * Returns the first question in QUESTIONS whose id is not in answeredIds.
+ * Returns null when every question has been answered.
+ * 
+ * @param answeredIds - An array of IDs representing questions that have already been answered.
+ * @returns The next Question to be answered, or null if the questionnaire is complete.
+ */
+export function nextQuestion(answeredIds: string[]): Question | null {
+  const next = QUESTIONS.find((q) => !answeredIds.includes(q.id));
+  return next ?? null;
+}

--- a/src/lib/questionnaire/questions.test.ts
+++ b/src/lib/questionnaire/questions.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { QUESTIONS } from './questions'
+
+describe('questions', () => {
+  it('has twelve questions', () => {
+    expect(QUESTIONS).toHaveLength(12)
+  })
+
+  it('every id is unique', () => {
+    const ids = QUESTIONS.map((q) => q.id)
+    const uniqueIds = new Set(ids)
+    expect(uniqueIds.size).toBe(QUESTIONS.length)
+  })
+
+  it('every question has a prompt ending in a question mark', () => {
+    QUESTIONS.forEach((q) => {
+      expect(q.prompt.length).toBeGreaterThan(0)
+      expect(q.prompt.endsWith('?')).toBe(true)
+    })
+  })
+
+  it('every field is a known domain field', () => {
+    const allowedFields = [
+      'likes',
+      'dislikes',
+      'jokes',
+      'moods',
+      'dreams',
+      'events',
+      'gifts',
+      'trips',
+    ] as const
+
+    QUESTIONS.forEach((q) => {
+      expect(allowedFields).toContain(q.field as any)
+    })
+  })
+})

--- a/src/lib/questionnaire/questions.ts
+++ b/src/lib/questionnaire/questions.ts
@@ -1,0 +1,22 @@
+export type QuestionField = 'likes' | 'dislikes' | 'jokes' | 'moods' | 'dreams' | 'events' | 'gifts' | 'trips';
+
+export interface Question {
+  id: string;
+  prompt: string;
+  field: QuestionField;
+}
+
+export const QUESTIONS: readonly Question[] = [
+  { id: 'favourite-things', prompt: 'What are some of your partner\'s favourite things?', field: 'likes' },
+  { id: 'small-joys', prompt: 'What are the small joys they find in everyday life?', field: 'likes' },
+  { id: 'pet-peeves', prompt: 'What are some of their biggest pet peeves?', field: 'dislikes' },
+  { id: 'stress-signals', prompt: 'How can you tell when they are feeling stressed?', field: 'moods' },
+  { id: 'comfort-response', prompt: 'How do they like to be comforted when they are down?', field: 'moods' },
+  { id: 'running-joke', prompt: 'What is a running joke that only the two of you understand?', field: 'jokes' },
+  { id: 'best-gift', prompt: 'What is the best gift they have ever received?', field: 'gifts' },
+  { id: 'gift-misses', prompt: 'What is a gift that was a total miss?', field: 'gifts' },
+  { id: 'dream-trip', prompt: 'If you could go anywhere, what would be your dream trip?', field: 'trips' },
+  { id: 'someday-dream', prompt: 'What is a dream they hope to achieve someday?', field: 'dreams' },
+  { id: 'proudest-moment', prompt: 'What is a moment they were incredibly proud of?', field: 'events' },
+  { id: 'hard-year', prompt: 'What was a particularly challenging year for them?', field: 'events' },
+] as const satisfies readonly Question[];

--- a/src/lib/suggestions/generate.test.ts
+++ b/src/lib/suggestions/generate.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { generateSuggestion } from './generate'
+import { prisma } from '@/lib/db'
+import { generate } from '@/lib/ai'
+import { getProfileContext } from '@/lib/profile/context'
+import type { SuggestionKind, Audience } from '@/lib/suggestions/prompt'
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    suggestion: {
+      findMany: vi.fn(),
+      create: vi.fn(),
+    },
+  },
+}))
+
+vi.mock('@/lib/ai', () => ({
+  generate: vi.fn(),
+}))
+
+vi.mock('@/lib/profile/context', () => ({
+  getProfileContext: vi.fn(),
+}))
+
+// Note: @/lib/suggestions/prompt is not mocked as per instructions
+
+describe('generateSuggestion', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns and persists a suggestion', async () => {
+    const profileId = 'profile-123'
+    const kind = 'gift' as SuggestionKind
+    const audience = 'for_her' as Audience
+    const generatedBody = 'a picnic'
+
+    // 1. Mock context resolving with data
+    vi.mocked(getProfileContext).mockResolvedValue({
+      name: 'Ada',
+      likes: [],
+      dislikes: [],
+      jokes: [],
+      dreams: [],
+      recentMoods: [],
+      recentEvents: [],
+      pastGifts: [],
+      pastTrips: [],
+    })
+
+    // 2. Mock existing suggestions (empty)
+    vi.mocked(prisma.suggestion.findMany).mockResolvedValue([])
+
+    // 3. Mock AI generation
+    vi.mocked(generate).mockResolvedValue(generatedBody)
+
+    // 4. Mock persistence
+    vi.mocked(prisma.suggestion.create).mockResolvedValue({
+      id: 'sug-1',
+      profileId,
+      body: generatedBody,
+      kind,
+      audience,
+      createdAt: new Date(Date.UTC(2024, 0, 1)),
+    } as any)
+
+    const result = await generateSuggestion(profileId, kind, audience)
+
+    expect(result).toBe(generatedBody)
+    expect(prisma.suggestion.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        profileId,
+        kind,
+        audience,
+        body: generatedBody,
+      }),
+    })
+  })
+
+  it('returns null for an unknown profile', async () => {
+    const profileId = 'unknown-id'
+    const kind = 'gift' as SuggestionKind
+    const audience = 'for_her' as Audience
+
+    // Mock context resolving to null
+    vi.mocked(getProfileContext).mockResolvedValue(null)
+
+    const result = await generateSuggestion(profileId, kind, audience)
+
+    expect(result).toBeNull()
+    expect(generate).not.toHaveBeenCalled()
+    expect(prisma.suggestion.create).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/suggestions/generate.ts
+++ b/src/lib/suggestions/generate.ts
@@ -1,0 +1,30 @@
+import { prisma } from '@/lib/db';
+import { generate } from '@/lib/ai';
+import { getProfileContext } from '@/lib/profile/context';
+import { buildSuggestionPrompt, type SuggestionKind, type Audience } from '@/lib/suggestions/prompt';
+
+export async function generateSuggestion(profileId: string, kind: SuggestionKind, audience: Audience): Promise<string | null> {
+  const context = await getProfileContext(profileId);
+  if (!context) {
+    return null;
+  }
+
+  const existingSuggestions = await prisma.suggestion.findMany({
+    where: { profileId },
+  });
+  const existingBodies = existingSuggestions.map((s) => s.body);
+
+  const prompt = buildSuggestionPrompt(context, existingBodies, kind, audience);
+  const body = await generate(prompt);
+
+  await prisma.suggestion.create({
+    data: {
+      profileId,
+      body,
+      kind,
+      audience,
+    },
+  });
+
+  return body;
+}

--- a/src/lib/suggestions/prompt.test.ts
+++ b/src/lib/suggestions/prompt.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import { buildSuggestionPrompt, type SuggestionKind, type Audience } from './prompt'
+import type { ProfileContext } from '@/lib/profile/context'
+
+describe('prompt', () => {
+  const base: ProfileContext = {
+    name: 'Ada',
+    likes: [],
+    dislikes: [],
+    jokes: [],
+    dreams: [],
+    recentMoods: [],
+    recentEvents: [],
+    pastGifts: [],
+    pastTrips: []
+  }
+
+  it('names the kind and audience', () => {
+    const kind: SuggestionKind = 'gift'
+    const audience: Audience = 'for_her'
+    const prompt = buildSuggestionPrompt(base, [], kind, audience)
+
+    expect(prompt).toContain('gift')
+    expect(prompt).toContain('for her')
+  })
+
+  it('lists existing suggestions to avoid', () => {
+    const existing = ['a picnic', 'a movie night']
+    const prompt = buildSuggestionPrompt(base, existing, 'date', 'for_us')
+
+    expect(prompt).toContain('a picnic')
+    expect(prompt).toContain('a movie night')
+    expect(prompt).toContain('Do not repeat any of these existing suggestions.')
+  })
+
+  it('no repeat section when nothing exists', () => {
+    const prompt = buildSuggestionPrompt(base, [], 'trip', 'for_family')
+
+    expect(prompt).not.toContain('repeat')
+    expect(prompt).not.toContain('Existing suggestions')
+  })
+})

--- a/src/lib/suggestions/prompt.ts
+++ b/src/lib/suggestions/prompt.ts
@@ -1,0 +1,26 @@
+import type { ProfileContext } from '@/lib/profile/context';
+
+export type SuggestionKind = 'date' | 'gift' | 'trip';
+export type Audience = 'for_her' | 'for_us' | 'for_family';
+
+export function buildSuggestionPrompt(
+  context: ProfileContext,
+  existing: string[],
+  kind: SuggestionKind,
+  audience: Audience
+): string {
+  const parts: string[] = [];
+
+  parts.push(`Generate exactly one new ${kind} suggestion ${audience.replace('_', ' ')} for ${context.name}.`);
+
+  if (context.likes.length > 0) {
+    parts.push(`Context for ${context.name}: Likes: ${context.likes.join(', ')}.`);
+  }
+
+  if (existing.length > 0) {
+    parts.push(`Existing suggestions to avoid repeating: ${existing.join(', ')}.`);
+    parts.push('Do not repeat any of these existing suggestions.');
+  }
+
+  return parts.join(' ');
+}

--- a/src/lib/telegram/parse.test.ts
+++ b/src/lib/telegram/parse.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import { parseUpdate } from './parse'
+
+describe('parse', () => {
+  it('extracts chat id and text', () => {
+    const update = {
+      message: {
+        chat: {
+          id: 4242,
+        },
+        text: 'hello',
+      },
+    }
+    const result = parseUpdate(update)
+    expect(result).toEqual({ chatId: '4242', text: 'hello' })
+  })
+
+  it('numeric chat id becomes a string', () => {
+    const update = {
+      message: {
+        chat: {
+          id: 12345,
+        },
+        text: 'test',
+      },
+    }
+    const result = parseUpdate(update)
+    expect(result?.chatId).toBe('12345')
+    expect(typeof result?.chatId).toBe('string')
+  })
+
+  it('non-text message returns null', () => {
+    const update = {
+      message: {
+        chat: {
+          id: 1,
+        },
+        photo: [],
+      },
+    }
+    const result = parseUpdate(update)
+    expect(result).toBeNull()
+  })
+
+  it('malformed input returns null', () => {
+    expect(parseUpdate(null)).toBeNull()
+    expect(parseUpdate({})).toBeNull()
+    expect(parseUpdate('nonsense')).toBeNull()
+  })
+})

--- a/src/lib/telegram/parse.ts
+++ b/src/lib/telegram/parse.ts
@@ -1,0 +1,32 @@
+export type IncomingMessage = {
+  chatId: string;
+  text: string;
+};
+
+export function parseUpdate(update: unknown): IncomingMessage | null {
+  if (update === null || typeof update !== 'object') {
+    return null;
+  }
+
+  const msg = (update as Record<string, unknown>).message;
+  if (!msg || typeof msg !== 'object') {
+    return null;
+  }
+
+  const chat = (msg as Record<string, unknown>).chat;
+  if (!chat || typeof chat !== 'object') {
+    return null;
+  }
+
+  const id = (chat as Record<string, unknown>).id;
+  const text = (msg as Record<string, unknown>).text;
+
+  if (id === undefined || text === undefined || typeof text !== 'string') {
+    return null;
+  }
+
+  return {
+    chatId: String(id),
+    text,
+  };
+}

--- a/src/lib/telegram/send.test.ts
+++ b/src/lib/telegram/send.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { sendMessage } from './send'
+
+describe('send', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn())
+    process.env = { ...originalEnv }
+  })
+
+  it('posts to the sendMessage endpoint', async () => {
+    process.env.TELEGRAM_POST_TOKEN = 'tok'
+    // Note: The implementation uses process.env.TELEGRAM_BOT_TOKEN
+    // We must set the correct key
+    process.env.TELEGRAM_BOT_TOKEN = 'tok'
+    
+    vi.mocked(fetch).mockResolvedValue({ ok: true } as Response)
+
+    await sendMessage('42', 'hi')
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/bottok/sendMessage'),
+      expect.anything()
+    )
+  })
+
+  it('sends chat id and text as JSON', async () => {
+    process.env.TELEGRAM_BOT_TOKEN = 'tok'
+    vi.mocked(fetch).mockResolvedValue({ ok: true } as Response)
+
+    await sendMessage('42', 'hi')
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        body: JSON.stringify({ chat_id: '42', text: 'hi' })
+      })
+    )
+  })
+
+  it('throws on non-ok response', async () => {
+    process.env.TELEGRAM_BOT_TOKEN = 'tok'
+    vi.mocked(fetch).mockResolvedValue({
+      ok: false,
+      statusText: 'Bad Request'
+    } as Response)
+
+    await expect(sendMessage('42', 'hi')).rejects.toThrow('Telegram API error')
+  })
+
+  it('throws when the bot token is unset', async () => {
+    delete process.env.TELEGRAM_BOT_TOKEN
+
+    await expect(sendMessage('42', 'hi')).rejects.toThrow()
+    expect(fetch).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/telegram/send.ts
+++ b/src/lib/telegram/send.ts
@@ -1,0 +1,27 @@
+const BOT_TOKEN = process.env.TELEGRAM_BOT_TOKEN;
+
+if (!BOT_TOKEN) {
+  // We don't throw here globally because process.env might be populated
+  // during test execution or runtime initialization. 
+  // The sendMessage function will check this explicitly.
+}
+
+export async function sendMessage(chatId: string, text: string): Promise<void> {
+  const token = process.env.TELEGRAM_BOT_TOKEN;
+
+  if (!token) {
+    throw new Error("TELEGRAM_BOT_TOKEN is not set");
+  }
+
+  const url = `https://api.telegram.org/bot${token}/sendMessage`;
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ chat_id: chatId, text }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Telegram API error: ${response.statusText}`);
+  }
+}

--- a/src/lib/telegram/verify.test.ts
+++ b/src/lib/telegram/verify.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest'
+import { verifyTelegramSecret } from './verify'
+
+describe('verify', () => {
+  it('matching secret is accepted', () => {
+    expect(verifyTelegramSecret('s3cret', 's3cret')).toBe(true)
+  })
+
+  it('different secret is rejected', () => {
+    expect(verifyTelegramSecret('wrong', 's3cret')).toBe(false)
+  })
+
+  it('different length is rejected without throwing', () => {
+    expect(verifyTelegramSecret('short', 'muchlongersecret')).toBe(false)
+  })
+
+  it('null header is rejected', () => {
+    expect(verifyTelegramSecret(null, 's3cret')).toBe(false)
+  })
+
+  it('unconfigured secret rejects everything', () => {
+    expect(verifyTelegramSecret('anything', undefined)).toBe(false)
+    expect(verifyTelegramSecret('', '')).toBe(false)
+  })
+})

--- a/src/lib/telegram/verify.ts
+++ b/src/lib/telegram/verify.ts
@@ -1,0 +1,25 @@
+import { timingSafeEqual } from 'node:crypto';
+
+/**
+ * Verifies the Telegram webhook secret token.
+ * Telegram sends the secret_token in the X-Telegram-Bot-Api-Secret-Token header.
+ * This function compares that header value against the configured secret.
+ */
+export function verifyTelegramSecret(headerValue: string | null, secret: string | undefined): boolean {
+  if (!secret || secret === '') {
+    return false;
+  }
+
+  if (headerValue === null) {
+    return false;
+  }
+
+  const headerBuffer = Buffer.from(headerValue);
+  const secretBuffer = Buffer.from(secret);
+
+  if (headerBuffer.length !== secretBuffer.length) {
+    return false;
+  }
+
+  return timingSafeEqual(headerBuffer, secretBuffer);
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/cron",
+      "schedule": "0 13 * * *"
+    }
+  ]
+}


### PR DESCRIPTION
Lands epic 2 from `dispatch/integration`: **17 stories, 1,447 insertions across 31 files.**

**Gates on the assembled branch, `.env.local` moved aside** (the CI condition): 70 tests / 20 files ✅ · tsc ✅ · lint ✅ · build ✅ with the proxy registered and `/api/cron` + `/api/telegram` dynamic.

### What's in it
- **Schema**: `TelegramChat`, `Message`, `QuestionnaireAnswer`, `Occasion` (recurring month/day + lead time), `CadenceRun` (unique per profile/kind/day — a re-triggered cron double-sends nothing)
- **Telegram**: timing-safe webhook secret verification, update parsing, sendMessage wrapper
- **Questionnaire**: 12 stable-id questions seeding likes/dislikes/jokes/moods/dreams/events/gifts/trips, resumable progress
- **Coach**: one-query profile retrieval, prompt builder grounded in the profile (no invented facts), conversation loop persisting both turns
- **Suggestions**: audience-tagged (`for_her`/`for_us`/`for_family`), kind-tagged, history-aware (no repeats)
- **Cadences**: pure date math (daily/weekly Sunday/monthly 1st, UTC), occasion lead-time reminders, one cron at 13:00 UTC fanning out
- **Routes**: thin webhook + cron handlers; 401 on bad secrets, 200-ack on unhandled update kinds so Telegram doesn't redeliver forever

### Provenance
**15 stories ground by Spike, 2 hand-written** (#39, #44 — the multi-mock routes story-lint predicted would hand off at filing time). The epic surfaced and fixed seven pipeline seams in spikes-workspace (PRs #44–#49 there).

### Before this is live
Vercel needs: auth (`NEXTAUTH_SECRET`, SMTP, `EMAIL_FROM`), `TELEGRAM_BOT_TOKEN` + `TELEGRAM_WEBHOOK_SECRET` (BotFather + `setWebhook`), `CRON_SECRET`, and a real `DATABASE_URL`. `.env.example` documents all of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgUuHL6M6pBwuwozBPFph3