### PR TITLE
docs: epic 2 and epic 3 story plans

### DIFF
--- a/docs/epics/epic-2-telegram-coach.md
+++ b/docs/epics/epic-2-telegram-coach.md
@@ -1,0 +1,433 @@
+# Epic 2 — Telegram coach: webhook, questionnaire, conversation loop, cadences
+
+Every module here is a plain `.ts` unit with a declared export and declared
+imports. The two route handlers are deliberately thin: they parse, delegate,
+and respond, so the logic worth testing lives in modules that need no HTTP.
+
+Framework note, verified against this repo: it runs **Next 16**. Route handlers
+live at `src/app/api/<name>/route.ts` and export named HTTP verbs (`POST`,
+`GET`). Do not use the Pages-router `export default function handler` shape.
+
+---
+
+## Story 1 — Telegram and cadence domain models
+
+**Files to modify:**
+- `prisma/schema.prisma`
+
+**Acceptance Criteria:**
+- `prisma/schema.prisma` gains exactly five models appended after the existing `Suggestion` model: `TelegramChat`, `Message`, `QuestionnaireAnswer`, `Occasion`, `CadenceRun`.
+- `TelegramChat` fields: `id String @id @default(cuid())`, `chatId String @unique`, `profileId String`, `createdAt DateTime @default(now())`, `profile Profile @relation(fields: [profileId], references: [id], onDelete: Cascade)`.
+- `Message` fields: `id String @id @default(cuid())`, `profileId String`, `role String`, `text String`, `createdAt DateTime @default(now())`, `profile Profile @relation(fields: [profileId], references: [id], onDelete: Cascade)`.
+- `QuestionnaireAnswer` fields: `id String @id @default(cuid())`, `profileId String`, `questionId String`, `answer String`, `createdAt DateTime @default(now())`, `profile Profile @relation(fields: [profileId], references: [id], onDelete: Cascade)`. Add `@@unique([profileId, questionId])`.
+- `Occasion` fields: `id String @id @default(cuid())`, `profileId String`, `kind String`, `label String`, `month Int`, `day Int`, `leadTimeDays Int @default(7)`, `createdAt DateTime @default(now())`, `profile Profile @relation(fields: [profileId], references: [id], onDelete: Cascade)`. Store month and day rather than a full date, because birthdays and anniversaries recur every year.
+- `CadenceRun` fields: `id String @id @default(cuid())`, `profileId String`, `kind String`, `ranOn DateTime`, `createdAt DateTime @default(now())`, `profile Profile @relation(fields: [profileId], references: [id], onDelete: Cascade)`. Add `@@unique([profileId, kind, ranOn])` so a re-run of the same cron day cannot double-send.
+- The existing `Profile` model gains these inverse arrays: `telegramChats TelegramChat[]`, `messages Message[]`, `questionnaireAnswers QuestionnaireAnswer[]`, `occasions Occasion[]`, `cadenceRuns CadenceRun[]`.
+- The existing `Suggestion` model gains one field: `kind String @default("date")`. Do NOT otherwise modify `Suggestion` or any other existing model.
+- Running `prisma generate` (no live DB required) completes without error.
+
+**Testing:** not applicable — Prisma schema file; there is no vitest unit under test.
+
+---
+
+## Story 2 — Telegram webhook secret verification
+
+**Files to create:**
+- `src/lib/telegram/verify.ts`
+- `src/lib/telegram/verify.test.ts`
+
+**Acceptance Criteria:**
+- Exports `verifyTelegramSecret(headerValue: string | null, secret: string | undefined): boolean` — the SOLE export of `src/lib/telegram/verify.ts`. Implement it exactly once; do NOT emit an alternate variant or re-export.
+- Imports `timingSafeEqual` from `'node:crypto'`. No other imports.
+- Telegram authenticates its webhook by echoing the `secret_token` given to `setWebhook` in the `X-Telegram-Bot-Api-Secret-Token` request header. This function compares that header against the configured secret.
+- Returns `false` when `secret` is undefined or empty — an unconfigured server must reject every request rather than accept every request.
+- Returns `false` when `headerValue` is null.
+- Returns `false` when the two strings differ in length, without calling `timingSafeEqual` (it throws on length mismatch).
+- Otherwise returns the result of a `timingSafeEqual` comparison over `Buffer.from(...)` of both strings.
+- `src/lib/telegram/verify.test.ts` imports ONLY `{ verifyTelegramSecret }` from `'./verify'`. Does NOT use `vi.mock`.
+- Test "matching secret is accepted": `expect(verifyTelegramSecret('s3cret', 's3cret')).toBe(true)`.
+- Test "different secret is rejected": `expect(verifyTelegramSecret('wrong', 's3cret')).toBe(false)`.
+- Test "different length is rejected without throwing": `expect(verifyTelegramSecret('short', 'muchlongersecret')).toBe(false)`.
+- Test "null header is rejected": `expect(verifyTelegramSecret(null, 's3cret')).toBe(false)`.
+- Test "unconfigured secret rejects everything": `expect(verifyTelegramSecret('anything', undefined)).toBe(false)` and `expect(verifyTelegramSecret('', '')).toBe(false)`.
+
+**Testing:**
+- Test matching secret is accepted
+- Test different secret is rejected
+- Test different length is rejected without throwing
+- Test null header is rejected
+- Test unconfigured secret rejects everything
+
+---
+
+## Story 3 — Parse a Telegram update
+
+**Files to create:**
+- `src/lib/telegram/parse.ts`
+- `src/lib/telegram/parse.test.ts`
+
+**Acceptance Criteria:**
+- Exports `parseUpdate(update: unknown): IncomingMessage | null` and the type `IncomingMessage` — these are the SOLE exports of `src/lib/telegram/parse.ts`. Implement `parseUpdate` exactly once; do NOT emit an alternate variant or re-export.
+- `IncomingMessage` is `{ chatId: string; text: string }`.
+- Imports nothing. It is a pure function over a plain object.
+- Reads `update.message.chat.id` and `update.message.text`, returning `{ chatId: String(id), text }`.
+- Returns `null` for any update that is not a text message — a missing `message`, a missing `text` (photos, stickers, joins), or a missing `chat.id`. Telegram sends many update kinds to the same webhook and the coach only handles text.
+- Does not throw on malformed input: `parseUpdate(null)`, `parseUpdate({})` and `parseUpdate('nonsense')` all return `null`.
+- `src/lib/telegram/parse.test.ts` imports ONLY `{ parseUpdate }` from `'./parse'`. Does NOT use `vi.mock`.
+- Test "extracts chat id and text": `parseUpdate({ message: { chat: { id: 4242 }, text: 'hello' } })` equals `{ chatId: '4242', text: 'hello' }`.
+- Test "numeric chat id becomes a string": asserts the returned `chatId` is `'4242'`, strictly equal, not the number.
+- Test "non-text message returns null": `parseUpdate({ message: { chat: { id: 1 }, photo: [] } })` is `null`.
+- Test "malformed input returns null": `parseUpdate(null)`, `parseUpdate({})`, and `parseUpdate('nonsense')` are each `null`.
+
+**Testing:**
+- Test extracts chat id and text
+- Test numeric chat id becomes a string
+- Test non-text message returns null
+- Test malformed input returns null
+
+---
+
+## Story 4 — Send a Telegram message
+
+**Files to create:**
+- `src/lib/telegram/send.ts`
+- `src/lib/telegram/send.test.ts`
+
+**Acceptance Criteria:**
+- Exports `sendMessage(chatId: string, text: string): Promise<void>` — the SOLE export of `src/lib/telegram/send.ts`. Implement it exactly once; do NOT emit an alternate variant or re-export.
+- Imports nothing except Node.js globals (`fetch`, `process`). No npm package imports, no Prisma, no Telegram SDK.
+- POSTs to `` `https://api.telegram.org/bot${process.env.TELEGRAM_BOT_TOKEN}/sendMessage` `` with header `{ 'Content-Type': 'application/json' }` and body `JSON.stringify({ chat_id: chatId, text })`.
+- Throws an `Error` when `!res.ok`, with a message containing `'Telegram API error'`.
+- Throws an `Error` when `process.env.TELEGRAM_BOT_TOKEN` is unset, before calling fetch. A request to a URL containing the literal string `undefined` would otherwise fail confusingly.
+- `src/lib/telegram/send.test.ts` imports ONLY `{ sendMessage }` from `'./send'`. Mocks global fetch with `vi.stubGlobal('fetch', vi.fn())`. Sets `process.env.TELEGRAM_BOT_TOKEN` in the tests that need it.
+- Test "posts to the sendMessage endpoint": sets the token to `'tok'`; mocks fetch resolving `{ ok: true }`; calls `sendMessage('42', 'hi')`; asserts fetch's first argument contains `'/bottok/sendMessage'`.
+- Test "sends chat id and text as JSON": asserts the request body parses to `{ chat_id: '42', text: 'hi' }`.
+- Test "throws on non-ok response": mocks fetch resolving `{ ok: false, statusText: 'Bad Request' }`; asserts `sendMessage('42', 'hi')` rejects.
+- Test "throws when the bot token is unset": deletes `process.env.TELEGRAM_BOT_TOKEN`; asserts `sendMessage('42', 'hi')` rejects and that fetch was not called.
+
+**Testing:**
+- Test posts to the sendMessage endpoint
+- Test sends chat id and text as JSON
+- Test throws on non-ok response
+- Test throws when the bot token is unset
+
+---
+
+## Story 5 — The questionnaire question set
+
+**Files to create:**
+- `src/lib/questionnaire/questions.ts`
+- `src/lib/questionnaire/questions.test.ts`
+
+**Acceptance Criteria:**
+- Exports the constant `QUESTIONS` and the type `Question` — these are the SOLE exports of `src/lib/questionnaire/questions.ts`. Define `QUESTIONS` exactly once; do NOT emit an alternate variant or re-export.
+- Imports nothing. It is a static data module.
+- `Question` is `{ id: string; prompt: string; field: string }`, where `field` names the domain model an answer feeds: one of `'likes'`, `'dislikes'`, `'jokes'`, `'moods'`, `'dreams'`, `'events'`, `'gifts'`, `'trips'`.
+- `QUESTIONS` is a readonly array of exactly 12 questions, declared `as const satisfies readonly Question[]`.
+- Every `id` is unique and kebab-case. Ids are stored in the database, so they must be stable.
+- The 12 questions cover, in this order: `favourite-things` (likes), `small-joys` (likes), `pet-peeves` (dislikes), `stress-signals` (moods), `comfort-response` (moods), `running-joke` (jokes), `best-gift` (gifts), `gift-misses` (gifts), `dream-trip` (trips), `someday-dream` (dreams), `proudest-moment` (events), `hard-year` (events).
+- Each `prompt` is a full question addressed to the user about their partner, ending in a question mark.
+- `src/lib/questionnaire/questions.test.ts` imports ONLY `{ QUESTIONS }` from `'./questions'`. Does NOT use `vi.mock`.
+- Test "has twelve questions": `expect(QUESTIONS).toHaveLength(12)`.
+- Test "every id is unique": builds a `Set` of ids and asserts its size equals `QUESTIONS.length`.
+- Test "every question has a prompt ending in a question mark": asserts every `prompt` is a non-empty string ending with `'?'`.
+- Test "every field is a known domain field": asserts every `field` is a member of the eight allowed strings.
+
+**Testing:**
+- Test has twelve questions
+- Test every id is unique
+- Test every question has a prompt ending in a question mark
+- Test every field is a known domain field
+
+---
+
+## Story 6 — Questionnaire progress
+
+**Depends on:** Story 5
+
+**Files to create:**
+- `src/lib/questionnaire/flow.ts`
+- `src/lib/questionnaire/flow.test.ts`
+
+**Acceptance Criteria:**
+- Exports `nextQuestion(answeredIds: string[]): Question | null` — the SOLE export of `src/lib/questionnaire/flow.ts`. Implement it exactly once; do NOT emit an alternate variant or re-export.
+- Imports `QUESTIONS` and the type `Question` from `'@/lib/questionnaire/questions'`. No other imports.
+- Returns the first question in `QUESTIONS` whose `id` is not in `answeredIds`.
+- Returns `null` when every question has been answered — that is the signal the questionnaire is complete and the daily conversation can begin.
+- Ignores unknown ids in `answeredIds` rather than throwing, so a renamed question cannot wedge a profile.
+- Is a pure function: it does not read the database. The caller supplies the answered ids.
+- `src/lib/questionnaire/flow.test.ts` imports ONLY `{ nextQuestion }` from `'./flow'` and `{ QUESTIONS }` from `'@/lib/questionnaire/questions'`. Does NOT use `vi.mock`.
+- Test "returns the first question when nothing is answered": `expect(nextQuestion([])).toEqual(QUESTIONS[0])`.
+- Test "skips answered questions": passes `[QUESTIONS[0].id]` and asserts the result equals `QUESTIONS[1]`.
+- Test "returns null when all are answered": passes every id and asserts the result is `null`.
+- Test "unknown ids are ignored": passes `['no-such-question']` and asserts the result equals `QUESTIONS[0]`.
+
+**Testing:**
+- Test returns the first question when nothing is answered
+- Test skips answered questions
+- Test returns null when all are answered
+- Test unknown ids are ignored
+
+---
+
+## Story 7 — Structured profile retrieval
+
+**Depends on:** Story 1
+
+**Files to create:**
+- `src/lib/profile/context.ts`
+- `src/lib/profile/context.test.ts`
+
+**Acceptance Criteria:**
+- Exports `getProfileContext(profileId: string): Promise<ProfileContext | null>` and the type `ProfileContext` — these are the SOLE exports of `src/lib/profile/context.ts`. Implement `getProfileContext` exactly once; do NOT emit an alternate variant or re-export.
+- Imports `prisma` from `'@/lib/db'`. No other imports.
+- `ProfileContext` is `{ name: string; likes: string[]; dislikes: string[]; jokes: string[]; dreams: string[]; recentMoods: { label: string; note: string | null }[]; recentEvents: { title: string; note: string | null }[]; pastGifts: string[]; pastTrips: string[] }`.
+- Fetches with a single `prisma.profile.findUnique` call: `where: { id: profileId }`, and an `include` that pulls `likes`, `dislikes`, `jokes`, `dreams`, `gifts`, `trips`, plus `moods` and `events` each with `orderBy` newest-first and `take: 10`. One query, not nine — this runs on every inbound message.
+- Returns `null` when the profile does not exist.
+- Maps each relation to its plain string or object form as typed above; `likes`, `dislikes` and `jokes` map to their `text`, `dreams` and `gifts` to their `description`, `trips` to their `destination`.
+- This is structured retrieval by entity type. It does NOT use embeddings, vector search, or a similarity index.
+- `src/lib/profile/context.test.ts` mocks `'@/lib/db'` with `vi.mock('@/lib/db', () => ({ prisma: { profile: { findUnique: vi.fn() } } }))`. Imports `{ getProfileContext }` from `'./context'` and `{ prisma }` from `'@/lib/db'`.
+- Test "returns null for an unknown profile": mocks `findUnique` resolving `null`; asserts the result is `null`.
+- Test "maps relations to plain strings": mocks `findUnique` resolving a profile with `name: 'Ada'`, `likes: [{ text: 'tea' }]`, `trips: [{ destination: 'Kyoto' }]`; asserts the result's `name` is `'Ada'`, `likes` equals `['tea']`, and `pastTrips` equals `['Kyoto']`.
+- Test "fetches everything in one query": asserts `prisma.profile.findUnique` was called exactly once.
+- Test "limits moods and events to ten, newest first": asserts the `include` passed to `findUnique` requests `take: 10` for both `moods` and `events`.
+
+**Testing:**
+- Test returns null for an unknown profile
+- Test maps relations to plain strings
+- Test fetches everything in one query
+- Test limits moods and events to ten, newest first
+
+---
+
+## Story 8 — Build the coach prompt
+
+**Depends on:** Story 7
+
+**Files to create:**
+- `src/lib/coach/prompt.ts`
+- `src/lib/coach/prompt.test.ts`
+
+**Acceptance Criteria:**
+- Exports `buildCoachPrompt(context: ProfileContext, history: { role: string; text: string }[], userMessage: string): string` — the SOLE export of `src/lib/coach/prompt.ts`. Implement it exactly once; do NOT emit an alternate variant or re-export.
+- Imports the type `ProfileContext` from `'@/lib/profile/context'`. No other imports.
+- Is a pure function: it builds and returns a string. It does not call the AI module, and it does not read the database.
+- The returned prompt opens with a role instruction naming the coach's job: helping the user understand and delight their partner, using only what the profile records.
+- Includes the partner's name and each non-empty section of the context under a plain labelled heading (`Likes:`, `Dislikes:`, `Jokes:`, `Dreams:`, `Recent moods:`, `Recent events:`, `Past gifts:`, `Past trips:`).
+- Omits a section entirely when its array is empty, rather than printing an empty heading — a new profile would otherwise be mostly blank labels.
+- Appends the conversation `history` in order, each line prefixed by its role, then the `userMessage` last.
+- Includes an instruction not to invent facts about the partner that are absent from the context.
+- `src/lib/coach/prompt.test.ts` imports ONLY `{ buildCoachPrompt }` from `'./prompt'`. Does NOT use `vi.mock`.
+- Test "includes the partner name": builds with a context whose `name` is `'Ada'`; asserts the result contains `'Ada'`.
+- Test "includes populated sections": builds with `likes: ['tea']`; asserts the result contains `'Likes:'` and `'tea'`.
+- Test "omits empty sections": builds with `dislikes: []`; asserts the result does NOT contain `'Dislikes:'`.
+- Test "ends with the user message": builds with the user message `'what should I plan?'`; asserts the result ends with a string containing `'what should I plan?'`.
+- Test "includes history in order": builds with history `[{ role: 'user', text: 'first' }, { role: 'assistant', text: 'second' }]`; asserts `indexOf('first')` is less than `indexOf('second')`.
+
+**Testing:**
+- Test includes the partner name
+- Test includes populated sections
+- Test omits empty sections
+- Test ends with the user message
+- Test includes history in order
+
+---
+
+## Story 9 — The conversation loop
+
+**Depends on:** Story 8
+
+**Files to create:**
+- `src/lib/coach/respond.ts`
+- `src/lib/coach/respond.test.ts`
+
+**Acceptance Criteria:**
+- Exports `respond(profileId: string, userMessage: string): Promise<string>` — the SOLE export of `src/lib/coach/respond.ts`. Implement it exactly once; do NOT emit an alternate variant or re-export.
+- Imports `prisma` from `'@/lib/db'`, `generate` from `'@/lib/ai'`, `getProfileContext` from `'@/lib/profile/context'`, and `buildCoachPrompt` from `'@/lib/coach/prompt'`. No other imports.
+- Loads the profile context, loads the last 20 `Message` rows for the profile ordered newest-first via `prisma.message.findMany`, reverses them into chronological order, builds the prompt, and calls `generate`.
+- Persists both sides of the exchange with `prisma.message.create`: the inbound message with `role: 'user'`, then the reply with `role: 'assistant'`.
+- Returns the generated reply text.
+- Returns the string `'I do not have a profile set up yet.'` when `getProfileContext` resolves `null`, without calling `generate`.
+- `src/lib/coach/respond.test.ts` mocks `'@/lib/db'`, `'@/lib/ai'`, and `'@/lib/profile/context'` with `vi.mock`. It does NOT mock `'@/lib/coach/prompt'` — that module is pure local code, and mocking it would make the test pass regardless of what the prompt builder does.
+- Test "returns the generated reply": mocks context resolving a profile and `generate` resolving `'a thoughtful reply'`; asserts `respond('p1', 'hi')` resolves to `'a thoughtful reply'`.
+- Test "persists both turns": asserts `prisma.message.create` was called twice, once with `role: 'user'` and once with `role: 'assistant'`.
+- Test "handles a missing profile": mocks context resolving `null`; asserts the returned string contains `'profile'` and that `generate` was not called.
+- Test "passes recent history to the prompt": mocks `findMany` resolving two messages; asserts `generate` was called once with a string containing both message texts.
+
+**Testing:**
+- Test returns the generated reply
+- Test persists both turns
+- Test handles a missing profile
+- Test passes recent history to the prompt
+
+---
+
+## Story 10 — Audience-tagged suggestions
+
+**Depends on:** Story 7
+
+**Files to create:**
+- `src/lib/suggestions/generate.ts`
+- `src/lib/suggestions/generate.test.ts`
+
+**Acceptance Criteria:**
+- Exports `generateSuggestion(profileId: string, kind: SuggestionKind, audience: Audience): Promise<string | null>` and the types `SuggestionKind` and `Audience` — these are the SOLE exports of `src/lib/suggestions/generate.ts`. Implement `generateSuggestion` exactly once; do NOT emit an alternate variant or re-export.
+- `SuggestionKind` is `'date' | 'gift' | 'trip'`. `Audience` is `'for_her' | 'for_us' | 'for_family'`.
+- Imports `prisma` from `'@/lib/db'`, `generate` from `'@/lib/ai'`, and `getProfileContext` from `'@/lib/profile/context'`. No other imports.
+- Loads the profile context and the profile's existing `Suggestion` rows via `prisma.suggestion.findMany`, then asks `generate` for one new suggestion of the given kind for the given audience.
+- The prompt lists the existing suggestion bodies and instructs the model not to repeat them. Suggestion history exists so the coach does not propose the same dinner every week.
+- Persists the result with `prisma.suggestion.create`, storing `body`, `kind`, `audience`, and `profileId`.
+- Returns the suggestion body, or `null` when the profile does not exist — without calling `generate` or `create`.
+- `src/lib/suggestions/generate.test.ts` mocks `'@/lib/db'`, `'@/lib/ai'`, and `'@/lib/profile/context'` with `vi.mock`.
+- Test "returns and persists a suggestion": mocks context resolving a profile and `generate` resolving `'a picnic'`; asserts the return is `'a picnic'` and that `prisma.suggestion.create` was called once.
+- Test "stores the kind and audience": asserts the object passed to `create` carries `kind: 'gift'` and `audience: 'for_her'`.
+- Test "tells the model not to repeat past suggestions": mocks `findMany` resolving `[{ body: 'a picnic' }]`; asserts `generate` was called with a string containing `'a picnic'`.
+- Test "returns null for an unknown profile": mocks context resolving `null`; asserts the result is `null` and that `generate` was not called.
+
+**Testing:**
+- Test returns and persists a suggestion
+- Test stores the kind and audience
+- Test tells the model not to repeat past suggestions
+- Test returns null for an unknown profile
+
+---
+
+## Story 11 — Which cadences are due
+
+**Files to create:**
+- `src/lib/cadence/due.ts`
+- `src/lib/cadence/due.test.ts`
+
+**Acceptance Criteria:**
+- Exports `dueCadences(today: Date): CadenceKind[]` and the type `CadenceKind` — these are the SOLE exports of `src/lib/cadence/due.ts`. Implement `dueCadences` exactly once; do NOT emit an alternate variant or re-export.
+- `CadenceKind` is `'daily' | 'weekly' | 'monthly'`.
+- Imports nothing. It is a pure function of the date it is given.
+- Takes `today` as a parameter. Does NOT call `new Date()`, `Date.now()`, or read the clock — a function that reads the clock cannot be tested for a Sunday on a Tuesday.
+- Always includes `'daily'`.
+- Includes `'weekly'` when `today.getUTCDay() === 0` (Sunday).
+- Includes `'monthly'` when `today.getUTCDate() === 1`.
+- Returns them in the order `daily`, `weekly`, `monthly`.
+- All comparisons use the UTC accessors, so the result does not depend on the server's timezone.
+- `src/lib/cadence/due.test.ts` imports ONLY `{ dueCadences }` from `'./due'`. Does NOT use `vi.mock` and does NOT use fake timers.
+- Test "a plain weekday is daily only": `dueCadences(new Date('2026-08-18T09:00:00Z'))` equals `['daily']`.
+- Test "Sunday adds weekly": `dueCadences(new Date('2026-08-23T09:00:00Z'))` equals `['daily', 'weekly']`.
+- Test "the first of the month adds monthly": `dueCadences(new Date('2026-09-01T09:00:00Z'))` equals `['daily', 'monthly']`.
+- Test "a Sunday the first returns all three": `dueCadences(new Date('2026-11-01T09:00:00Z'))` equals `['daily', 'weekly', 'monthly']`.
+
+**Testing:**
+- Test a plain weekday is daily only
+- Test Sunday adds weekly
+- Test the first of the month adds monthly
+- Test a Sunday the first returns all three
+
+---
+
+## Story 12 — Which occasions are approaching
+
+**Depends on:** Story 1
+
+**Files to create:**
+- `src/lib/cadence/occasions.ts`
+- `src/lib/cadence/occasions.test.ts`
+
+**Acceptance Criteria:**
+- Exports `dueOccasions(occasions: OccasionInput[], today: Date): OccasionInput[]` and the type `OccasionInput` — these are the SOLE exports of `src/lib/cadence/occasions.ts`. Implement `dueOccasions` exactly once; do NOT emit an alternate variant or re-export.
+- `OccasionInput` is `{ id: string; kind: string; label: string; month: number; day: number; leadTimeDays: number }`, where `month` is 1-12.
+- Imports nothing. It is a pure function of the values it is given.
+- Takes `today` as a parameter. Does NOT call `new Date()` or `Date.now()`.
+- Returns every occasion whose next anniversary falls between `today` inclusive and `today + leadTimeDays` inclusive — the reminder should arrive with enough lead time to actually buy something.
+- Computes the next occurrence in the current year, and rolls to next year when that date has already passed. A birthday on 3 January is due in late December, not eleven months away.
+- Returns an empty array when nothing is approaching.
+- `src/lib/cadence/occasions.test.ts` imports ONLY `{ dueOccasions }` from `'./occasions'`. Does NOT use `vi.mock` and does NOT use fake timers.
+- Test "an occasion inside the lead window is due": one occasion on 20 August with `leadTimeDays: 7`, today `new Date('2026-08-17T00:00:00Z')`; asserts the result has length 1.
+- Test "an occasion beyond the lead window is not due": the same occasion with today `new Date('2026-08-01T00:00:00Z')`; asserts the result is empty.
+- Test "an occasion today is due": one occasion on 17 August, today `new Date('2026-08-17T00:00:00Z')`; asserts the result has length 1.
+- Test "a passed occasion rolls to next year": one occasion on 3 January with `leadTimeDays: 14`, today `new Date('2026-12-27T00:00:00Z')`; asserts the result has length 1.
+- Test "returns empty when nothing is approaching": passes an empty array; asserts the result equals `[]`.
+
+**Testing:**
+- Test an occasion inside the lead window is due
+- Test an occasion beyond the lead window is not due
+- Test an occasion today is due
+- Test a passed occasion rolls to next year
+- Test returns empty when nothing is approaching
+
+---
+
+## Story 13 — Telegram webhook route
+
+**Depends on:** Story 9
+
+**Files to create:**
+- `src/app/api/telegram/route.ts`
+- `src/app/api/telegram/route.test.ts`
+
+**Acceptance Criteria:**
+- Exports the async function `POST(request: Request): Promise<Response>` — the SOLE export of `src/app/api/telegram/route.ts`. This is the Next 16 App Router convention; do NOT write `export default function handler`.
+- Imports `verifyTelegramSecret` from `'@/lib/telegram/verify'`, `parseUpdate` from `'@/lib/telegram/parse'`, `sendMessage` from `'@/lib/telegram/send'`, `respond` from `'@/lib/coach/respond'`, and `prisma` from `'@/lib/db'`. No other imports.
+- Reads the `x-telegram-bot-api-secret-token` header and passes it with `process.env.TELEGRAM_WEBHOOK_SECRET` to `verifyTelegramSecret`. Returns a 401 response when it returns false, before reading the body.
+- Parses the JSON body and passes it to `parseUpdate`. Returns 200 with body `{ ok: true }` when it returns `null` — Telegram retries any non-2xx, so an unhandled update kind must still be acknowledged rather than redelivered forever.
+- Looks up the `TelegramChat` row by `chatId` via `prisma.telegramChat.findUnique`. When there is no such row, sends a message telling the user to link their account and returns 200.
+- Otherwise calls `respond(chat.profileId, text)`, sends the reply with `sendMessage`, and returns 200 with `{ ok: true }`.
+- The route is thin: it verifies, parses, delegates, and answers. It contains no prompt text and no database writes of its own.
+- `src/app/api/telegram/route.test.ts` mocks `'@/lib/telegram/send'`, `'@/lib/coach/respond'`, and `'@/lib/db'` with `vi.mock`. It does NOT mock `'@/lib/telegram/verify'` or `'@/lib/telegram/parse'` — those are pure local modules, and mocking them would mean the test asserts nothing about whether unauthorised requests are actually rejected. Sets `process.env.TELEGRAM_WEBHOOK_SECRET` in tests.
+- Test "rejects a request with the wrong secret": posts with a bad header; asserts the response status is 401 and that `respond` was not called.
+- Test "acknowledges a non-text update": posts a valid-secret request whose body has no `message.text`; asserts the status is 200 and that `respond` was not called.
+- Test "replies to a known chat": mocks `findUnique` resolving `{ profileId: 'p1' }` and `respond` resolving `'hello back'`; asserts `sendMessage` was called with the chat id and `'hello back'`.
+- Test "prompts an unknown chat to link": mocks `findUnique` resolving `null`; asserts the status is 200, `respond` was not called, and `sendMessage` was called.
+
+**Testing:**
+- Test rejects a request with the wrong secret
+- Test acknowledges a non-text update
+- Test replies to a known chat
+- Test prompts an unknown chat to link
+
+---
+
+## Story 14 — Cron cadence route
+
+**Depends on:** Story 11
+
+**Files to create:**
+- `src/app/api/cron/route.ts`
+- `src/app/api/cron/route.test.ts`
+
+**Acceptance Criteria:**
+- Exports the async function `GET(request: Request): Promise<Response>` — the SOLE export of `src/app/api/cron/route.ts`. Vercel Cron invokes endpoints with GET. This is the Next 16 App Router convention; do NOT write `export default function handler`.
+- Imports `dueCadences` from `'@/lib/cadence/due'`, `dueOccasions` from `'@/lib/cadence/occasions'`, `respond` from `'@/lib/coach/respond'`, `sendMessage` from `'@/lib/telegram/send'`, and `prisma` from `'@/lib/db'`. No other imports.
+- Returns 401 when the `authorization` header does not equal `` `Bearer ${process.env.CRON_SECRET}` ``, or when `CRON_SECRET` is unset. This endpoint would otherwise let anyone on the internet trigger messages.
+- Computes `const today = new Date()` once at the top of the handler and passes it to both `dueCadences` and `dueOccasions`. The two pure modules never read the clock themselves.
+- For each profile with a linked `TelegramChat`, for each due cadence kind, calls `respond` with a cadence-appropriate opener and sends the reply.
+- Records each send as a `CadenceRun` row with `kind` and `ranOn` set to the UTC date, so a second invocation on the same day sends nothing. Skips any cadence whose `CadenceRun` for that profile, kind and date already exists.
+- Also sends one reminder per due occasion, naming the occasion label and how many days remain.
+- Returns 200 with a JSON body reporting how many messages were sent.
+- `src/app/api/cron/route.test.ts` mocks `'@/lib/db'`, `'@/lib/coach/respond'`, and `'@/lib/telegram/send'` with `vi.mock`. It does NOT mock `'@/lib/cadence/due'` or `'@/lib/cadence/occasions'` — those are pure local modules. Sets `process.env.CRON_SECRET` in tests.
+- Test "rejects a request without the cron secret": no authorization header; asserts the status is 401 and that `sendMessage` was not called.
+- Test "sends the daily check-in": mocks one profile with a chat and no prior `CadenceRun`; asserts `sendMessage` was called at least once.
+- Test "does not resend a cadence already run today": mocks a matching `CadenceRun` as already present; asserts `sendMessage` was not called for that kind.
+- Test "reports the number of messages sent": asserts the JSON body carries a numeric count.
+
+**Testing:**
+- Test rejects a request without the cron secret
+- Test sends the daily check-in
+- Test does not resend a cadence already run today
+- Test reports the number of messages sent
+
+---
+
+## Story 15 — Cron schedule and Telegram env variables
+
+**Depends on:** Story 14
+
+**Files to create:**
+- `vercel.json`
+
+**Files to modify:**
+- `.env.example`
+
+**Acceptance Criteria:**
+- `vercel.json` contains a `crons` array with exactly one entry: `{ "path": "/api/cron", "schedule": "0 13 * * *" }`. One daily invocation at 13:00 UTC; the cadence module decides from the date whether that day is also weekly or monthly, so no second cron entry is needed.
+- `.env.example` gains `TELEGRAM_BOT_TOKEN`, `TELEGRAM_WEBHOOK_SECRET`, and `CRON_SECRET`, each with an empty or placeholder value and a short comment saying what it is for.
+- Does NOT add real values for any of them, and does NOT modify `.env`.
+
+**Testing:** not applicable — configuration files; there is no vitest unit under test.

--- a/docs/epics/epic-3-web-ui.md
+++ b/docs/epics/epic-3-web-ui.md
@@ -1,0 +1,421 @@
+# Epic 3 — Web UI: visual portrait, study metrics, profile editing
+
+The shape that ground reliably in epic 2, applied to UI work: **pure modules
+compute, components render props, pages assemble.** Every metric is a pure
+function taking its inputs (including `today`) as parameters. Components take
+plain props and their tests mock nothing. The page is thin: it loads, computes,
+and hands everything to one assembly component. The two shapes that handed off
+in epic 2 — units with 3+ mocked collaborators — do not appear in this epic by
+construction.
+
+Framework notes, verified against this repo: **Next 16**, App Router. Pages are
+server components unless marked `'use client'`. Route auth is already global via
+`src/proxy.ts` — no story here touches auth. Component tests run under jsdom
+with @testing-library/react (installed; `vitest.setup.ts` handles env).
+
+Type facts every story must respect (from `prisma/schema.prisma` on develop):
+`Mood` rows carry `label String`, `note String?`, `recordedAt DateTime`.
+`Gift` rows carry `description String`, `givenAt DateTime?`. `Dream` rows carry
+`description String`. `LikesEntry`/`DislikesEntry`/`Joke` rows carry `text String`.
+
+---
+
+## Story 1 — Gift outcome field
+
+**Files to modify:**
+- `prisma/schema.prisma`
+
+**Acceptance Criteria:**
+- The existing `Gift` model gains exactly one field: `howItLanded String?`, placed after `givenAt`.
+- No other model, field, or attribute is added, removed, or reordered.
+- Running `prisma generate` (no live DB required) completes without error.
+
+**Testing:** not applicable — Prisma schema file; there is no vitest unit under test.
+
+---
+
+## Story 2 — Load the full portrait
+
+**Depends on:** Story 1
+
+**Files to create:**
+- `src/lib/portrait/load.ts`
+- `src/lib/portrait/load.test.ts`
+
+**Acceptance Criteria:**
+- Exports `getPortrait(profileId: string): Promise<Portrait | null>` and the type `Portrait` — these are the SOLE exports of `src/lib/portrait/load.ts`. Implement `getPortrait` exactly once; do NOT emit an alternate variant or re-export.
+- Imports `prisma` from `'@/lib/db'`. No other imports.
+- `Portrait` is `{ name: string; likes: string[]; dislikes: string[]; jokes: string[]; dreams: string[]; moods: { label: string; note: string | null; recordedAt: Date }[]; events: { title: string; note: string | null; occurredAt: Date }[]; gifts: { description: string; givenAt: Date | null; howItLanded: string | null }[]; trips: string[]; occasions: { label: string; month: number; day: number }[] }`.
+- Fetches with a single `prisma.profile.findUnique` call: `where: { id: profileId }`, and an `include` that pulls `likes`, `dislikes`, `jokes`, `dreams`, `gifts`, `trips`, `occasions`, plus `moods` with `orderBy: { recordedAt: 'asc' }` (full history, oldest first — the timeline needs all of it) and `events` with `orderBy: { occurredAt: 'desc' }` and `take: 20`. One query, not ten.
+- Returns `null` when the profile does not exist.
+- Maps relations to the `Portrait` shape: `likes`, `dislikes`, `jokes` map each row to its `text`; `dreams` maps each row to its `description`; `trips` maps each row to its `destination`. `moods`, `events`, `gifts`, `occasions` keep the object fields named in the `Portrait` type and drop everything else.
+- `src/lib/portrait/load.test.ts` mocks `'@/lib/db'` with `vi.mock('@/lib/db', () => ({ prisma: { profile: { findUnique: vi.fn() } } }))` — the ONLY mock in the file. Prisma-row mock values use the established idiom `vi.mocked(prisma.profile.findUnique).mockResolvedValue(row as never)` — do NOT construct full Prisma row types.
+- Test "returns null for an unknown profile": mocks `findUnique` resolving `null`; asserts the result is `null`.
+- Test "maps text rows to plain strings": mocks a profile with `name: 'Ada'`, `likes: [{ text: 'tea' }]`, `dreams: [{ description: 'a cabin' }]`, all other relations empty arrays; asserts `likes` equals `['tea']` and `dreams` equals `['a cabin']`.
+- Test "keeps mood fields for the timeline": mocks `moods: [{ label: 'happy', note: null, recordedAt: new Date('2026-08-01T00:00:00Z') }]`; asserts the result's first mood's `label` is `'happy'` and its `recordedAt` is a `Date`.
+- Test "fetches everything in one query": asserts `prisma.profile.findUnique` was called exactly once, and that the `include` passed to it requests `moods` with `orderBy: { recordedAt: 'asc' }`.
+
+**Testing:**
+- Test returns null for an unknown profile
+- Test maps text rows to plain strings
+- Test keeps mood fields for the timeline
+- Test fetches everything in one query
+
+---
+
+## Story 3 — Coverage metric
+
+**Files to create:**
+- `src/lib/metrics/coverage.ts`
+- `src/lib/metrics/coverage.test.ts`
+
+**Acceptance Criteria:**
+- Exports `coverage(counts: Record<string, number>): Coverage` and the type `Coverage` — these are the SOLE exports of `src/lib/metrics/coverage.ts`. Implement `coverage` exactly once; do NOT emit an alternate variant or re-export.
+- Imports nothing. It is a pure function over the counts it is given — the caller supplies `{ likes: 3, dislikes: 0, ... }` however it likes.
+- `Coverage` is `{ filled: number; total: number; gaps: string[] }`.
+- `filled` is the number of keys whose count is greater than 0; `total` is the number of keys; `gaps` is the keys whose count is 0, in the input's key order.
+- An empty input returns `{ filled: 0, total: 0, gaps: [] }`.
+- `src/lib/metrics/coverage.test.ts` imports ONLY `{ coverage }` from `'./coverage'`. Does NOT use `vi.mock`.
+- Test "counts filled and total": `coverage({ likes: 3, dislikes: 0, jokes: 1 })` equals `{ filled: 2, total: 3, gaps: ['dislikes'] }`.
+- Test "all filled means no gaps": `coverage({ likes: 1, jokes: 2 })` has `gaps` equal to `[]`.
+- Test "empty input is empty coverage": `coverage({})` equals `{ filled: 0, total: 0, gaps: [] }`.
+
+**Testing:**
+- Test counts filled and total
+- Test all filled means no gaps
+- Test empty input is empty coverage
+
+---
+
+## Story 4 — Recency metric
+
+**Files to create:**
+- `src/lib/metrics/recency.ts`
+- `src/lib/metrics/recency.test.ts`
+
+**Acceptance Criteria:**
+- Exports `daysSinceLastTouch(dates: Date[], today: Date): number | null` — the SOLE export of `src/lib/metrics/recency.ts`. Implement it exactly once; do NOT emit an alternate variant or re-export.
+- Imports nothing. Takes `today` as a parameter; does NOT call `new Date()` or `Date.now()`.
+- Returns the whole number of days (floor of the millisecond difference divided by 86,400,000) between `today` and the LATEST date in `dates`.
+- Returns `null` when `dates` is empty — a brand-new profile has no last touch, and `0` would lie about that.
+- Returns `0` when the latest date is today or in the future.
+- `src/lib/metrics/recency.test.ts` imports ONLY `{ daysSinceLastTouch }` from `'./recency'`. Does NOT use `vi.mock` and does NOT use fake timers.
+- Test "days since the latest date": passes `[new Date('2026-08-10T00:00:00Z'), new Date('2026-08-15T00:00:00Z')]` with today `new Date('2026-08-18T00:00:00Z')`; asserts the result is `3`.
+- Test "empty history is null": `daysSinceLastTouch([], new Date('2026-08-18T00:00:00Z'))` is `null`.
+- Test "a touch today is zero": passes `[new Date('2026-08-18T09:00:00Z')]` with today `new Date('2026-08-18T12:00:00Z')`; asserts the result is `0`.
+
+**Testing:**
+- Test days since the latest date
+- Test empty history is null
+- Test a touch today is zero
+
+---
+
+## Story 5 — Gift outcome stats
+
+**Depends on:** Story 1
+
+**Files to create:**
+- `src/lib/metrics/gifts.ts`
+- `src/lib/metrics/gifts.test.ts`
+
+**Acceptance Criteria:**
+- Exports `giftStats(gifts: { howItLanded: string | null }[]): GiftStats` and the type `GiftStats` — these are the SOLE exports of `src/lib/metrics/gifts.ts`. Implement `giftStats` exactly once; do NOT emit an alternate variant or re-export.
+- Imports nothing. It is a pure function.
+- `GiftStats` is `{ logged: number; hits: number; misses: number; unrated: number; successRate: number | null }`.
+- `hits` counts gifts whose `howItLanded` is exactly `'hit'`; `misses` counts exactly `'miss'`; everything else (including `null` and unknown strings) is `unrated`.
+- `successRate` is `hits / (hits + misses)` — rated gifts only — or `null` when no gift is rated. Never divide by zero.
+- `src/lib/metrics/gifts.test.ts` imports ONLY `{ giftStats }` from `'./gifts'`. Does NOT use `vi.mock`.
+- Test "counts hits misses and unrated": passes `[{ howItLanded: 'hit' }, { howItLanded: 'hit' }, { howItLanded: 'miss' }, { howItLanded: null }]`; asserts `{ logged: 4, hits: 2, misses: 1, unrated: 1, successRate: 2 / 3 }`.
+- Test "no rated gifts means null success rate": passes `[{ howItLanded: null }]`; asserts `successRate` is `null` and `unrated` is `1`.
+- Test "empty list is all zeros": passes `[]`; asserts `{ logged: 0, hits: 0, misses: 0, unrated: 0, successRate: null }`.
+
+**Testing:**
+- Test counts hits misses and unrated
+- Test no rated gifts means null success rate
+- Test empty list is all zeros
+
+---
+
+## Story 6 — Mood timeline buckets
+
+**Files to create:**
+- `src/lib/metrics/moodBuckets.ts`
+- `src/lib/metrics/moodBuckets.test.ts`
+
+**Acceptance Criteria:**
+- Exports `moodBuckets(moods: { label: string; recordedAt: Date }[]): MoodBucket[]` and the type `MoodBucket` — these are the SOLE exports of `src/lib/metrics/moodBuckets.ts`. Implement `moodBuckets` exactly once; do NOT emit an alternate variant or re-export.
+- Imports nothing. Takes no `today` and reads no clock — it buckets whatever it is given.
+- `MoodBucket` is `{ day: string; labels: string[] }`, where `day` is the UTC calendar date formatted exactly `YYYY-MM-DD` (from `recordedAt.toISOString().slice(0, 10)`).
+- Groups moods by `day`; within a bucket, `labels` keeps the input order. Buckets are sorted by `day` ascending.
+- An empty input returns `[]`.
+- `src/lib/metrics/moodBuckets.test.ts` imports ONLY `{ moodBuckets }` from `'./moodBuckets'`. Does NOT use `vi.mock` and does NOT use fake timers.
+- Test "groups same-day moods into one bucket": passes two moods on `2026-08-17` (different times) and one on `2026-08-18`; asserts the result has length 2 and the first bucket's `labels` has length 2.
+- Test "buckets are sorted by day ascending": passes the `2026-08-18` mood BEFORE the `2026-08-17` moods in the input; asserts `result[0].day` is `'2026-08-17'`.
+- Test "empty input is an empty array": `moodBuckets([])` equals `[]`.
+
+**Testing:**
+- Test groups same-day moods into one bucket
+- Test buckets are sorted by day ascending
+- Test empty input is an empty array
+
+---
+
+## Story 7 — Portrait list section component
+
+**Files to create:**
+- `src/components/PortraitSection.tsx`
+- `src/components/PortraitSection.test.tsx`
+
+**Acceptance Criteria:**
+- Default-exports a component named `PortraitSection` — the SOLE export of `src/components/PortraitSection.tsx`. Implement it exactly once; do NOT emit an alternate variant or re-export.
+- Props: `{ title: string; items: string[] }`. Imports nothing except React (JSX only — no hooks, no `'use client'`; it is a server-renderable presentational component).
+- Renders the `title` in a heading element and each item as an `<li>` inside a `<ul>`.
+- When `items` is empty, renders the title and, instead of a list, a paragraph containing the exact text `Nothing here yet.` — an empty portrait section invites filling in, it does not vanish.
+- The root element carries `data-testid="portrait-section"`.
+- `src/components/PortraitSection.test.tsx` imports `{ render, screen }` from `'@testing-library/react'` and `PortraitSection` (default) from `'./PortraitSection'`. Does NOT use `vi.mock`.
+- Test "renders the title and items": renders with `title="Likes"` and `items={['tea', 'rain']}`; asserts `screen.getByText('Likes')` exists and `screen.getAllByRole('listitem')` has length 2.
+- Test "empty items show the placeholder": renders with `items={[]}`; asserts `screen.getByText('Nothing here yet.')` exists and `screen.queryByRole('list')` is `null`.
+
+**Testing:**
+- Test renders the title and items
+- Test empty items show the placeholder
+
+---
+
+## Story 8 — Mood timeline component
+
+**Depends on:** Story 6
+
+**Files to create:**
+- `src/components/MoodTimeline.tsx`
+- `src/components/MoodTimeline.test.tsx`
+
+**Acceptance Criteria:**
+- Default-exports a component named `MoodTimeline` — the SOLE export of `src/components/MoodTimeline.tsx`.
+- Props: `{ buckets: MoodBucket[] }`. Imports the type `MoodBucket` from `'@/lib/metrics/moodBuckets'`. No other imports except React. No hooks, no `'use client'`.
+- Renders one row per bucket: the `day` string, followed by each label in that bucket. Each row carries `data-testid="mood-day"`.
+- When `buckets` is empty, renders a paragraph containing the exact text `No moods recorded yet.`
+- `src/components/MoodTimeline.test.tsx` imports `{ render, screen }` from `'@testing-library/react'` and `MoodTimeline` (default) from `'./MoodTimeline'`. Does NOT use `vi.mock`.
+- Test "renders one row per day": renders with two buckets; asserts `screen.getAllByTestId('mood-day')` has length 2.
+- Test "shows the day and its labels": renders with `[{ day: '2026-08-17', labels: ['happy', 'tired'] }]`; asserts text `2026-08-17`, `happy`, and `tired` are each present.
+- Test "empty timeline shows the placeholder": renders with `buckets={[]}`; asserts `screen.getByText('No moods recorded yet.')` exists.
+
+**Testing:**
+- Test renders one row per day
+- Test shows the day and its labels
+- Test empty timeline shows the placeholder
+
+---
+
+## Story 9 — Study metrics cards component
+
+**Depends on:** Story 3, Story 4, Story 5
+
+**Files to create:**
+- `src/components/StudyMetrics.tsx`
+- `src/components/StudyMetrics.test.tsx`
+
+**Acceptance Criteria:**
+- Default-exports a component named `StudyMetrics` — the SOLE export of `src/components/StudyMetrics.tsx`.
+- Props: `{ coverage: Coverage; daysSinceTouch: number | null; gifts: GiftStats }`. Imports the type `Coverage` from `'@/lib/metrics/coverage'` and the type `GiftStats` from `'@/lib/metrics/gifts'`. No other imports except React. No hooks, no `'use client'`.
+- Renders three labelled figures: coverage as the exact text `{filled} of {total} areas filled` (e.g. `7 of 10 areas filled`), recency as `Updated today` when `daysSinceTouch` is `0`, `Updated {n} days ago` when it is a positive number, and `Never updated` when it is `null`, and gifts as `{hits} of {rated} gifts landed` where `rated` is `hits + misses`, or `No gifts rated yet` when `successRate` is `null`.
+- When `coverage.gaps` is non-empty, renders each gap name inside an element with `data-testid="coverage-gap"`.
+- `src/components/StudyMetrics.test.tsx` imports `{ render, screen }` from `'@testing-library/react'` and `StudyMetrics` (default) from `'./StudyMetrics'`. Does NOT use `vi.mock`.
+- Test "shows coverage and gaps": renders with `coverage={{ filled: 2, total: 3, gaps: ['jokes'] }}`; asserts text `2 of 3 areas filled` and one `coverage-gap` containing `jokes`.
+- Test "shows recency in days": renders with `daysSinceTouch={5}`; asserts text `Updated 5 days ago`.
+- Test "never updated and no rated gifts": renders with `daysSinceTouch={null}` and `gifts={{ logged: 1, hits: 0, misses: 0, unrated: 1, successRate: null }}`; asserts texts `Never updated` and `No gifts rated yet`.
+
+**Testing:**
+- Test shows coverage and gaps
+- Test shows recency in days
+- Test never updated and no rated gifts
+
+---
+
+## Story 10 — Gift history component
+
+**Depends on:** Story 2
+
+**Files to create:**
+- `src/components/GiftHistory.tsx`
+- `src/components/GiftHistory.test.tsx`
+
+**Acceptance Criteria:**
+- Default-exports a component named `GiftHistory` — the SOLE export of `src/components/GiftHistory.tsx`.
+- Props: `{ gifts: { description: string; givenAt: Date | null; howItLanded: string | null }[] }` — the `Portrait['gifts']` element shape, restated here so the component does not import the loader. Imports nothing except React. No hooks, no `'use client'`.
+- Renders each gift as a list item showing its `description` and an outcome badge: the exact text `landed` when `howItLanded` is `'hit'`, `missed` when `'miss'`, and `unrated` otherwise. The badge element carries `data-testid="gift-outcome"`.
+- When `gifts` is empty, renders a paragraph containing the exact text `No gifts logged yet.`
+- `src/components/GiftHistory.test.tsx` imports `{ render, screen }` from `'@testing-library/react'` and `GiftHistory` (default) from `'./GiftHistory'`. Does NOT use `vi.mock`.
+- Test "renders each gift with its outcome": renders with a `'hit'` gift and a `null` gift; asserts two `gift-outcome` badges with texts `landed` and `unrated`.
+- Test "empty history shows the placeholder": renders with `gifts={[]}`; asserts `screen.getByText('No gifts logged yet.')` exists.
+
+**Testing:**
+- Test renders each gift with its outcome
+- Test empty history shows the placeholder
+
+---
+
+## Story 11 — Add-mood server action
+
+**Files to create:**
+- `src/app/actions/addMood.ts`
+- `src/app/actions/addMood.test.ts`
+
+**Acceptance Criteria:**
+- Exports `addMood(profileId: string, label: string, note: string | null): Promise<{ ok: boolean }>` — the SOLE export of `src/app/actions/addMood.ts`. The file's first line is the directive `'use server'`.
+- Imports `prisma` from `'@/lib/db'` and `revalidatePath` from `'next/cache'`. No other imports.
+- Returns `{ ok: false }` without any database call when `label` (trimmed) is empty.
+- Otherwise calls `prisma.mood.create` exactly once with `data: { profileId, label: <trimmed label>, note }`, then `revalidatePath('/portrait')`, then returns `{ ok: true }`. Does NOT pass `recordedAt` — the schema default supplies it.
+- `src/app/actions/addMood.test.ts` mocks `'@/lib/db'` with `vi.mock('@/lib/db', () => ({ prisma: { mood: { create: vi.fn() } } }))` and `'next/cache'` with `vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }))`. Prisma mock resolutions use `as never`.
+- Test "creates the mood and revalidates": calls `addMood('p1', 'happy', null)`; asserts the result is `{ ok: true }`, `prisma.mood.create` was called with `data: { profileId: 'p1', label: 'happy', note: null }`, and `revalidatePath` was called with `'/portrait'`.
+- Test "empty label is rejected without a db call": calls `addMood('p1', '   ', null)`; asserts `{ ok: false }` and that `prisma.mood.create` was not called.
+- Test "label is trimmed": calls `addMood('p1', '  calm ', 'after dinner')`; asserts `create` received `label: 'calm'` and `note: 'after dinner'`.
+
+**Testing:**
+- Test creates the mood and revalidates
+- Test empty label is rejected without a db call
+- Test label is trimmed
+
+---
+
+## Story 12 — Add-entry server action
+
+**Files to create:**
+- `src/app/actions/addEntry.ts`
+- `src/app/actions/addEntry.test.ts`
+
+**Acceptance Criteria:**
+- Exports `addEntry(profileId: string, field: EntryField, text: string): Promise<{ ok: boolean }>` and the type `EntryField` — these are the SOLE exports of `src/app/actions/addEntry.ts`. The file's first line is the directive `'use server'`.
+- `EntryField` is `'likes' | 'dislikes' | 'jokes' | 'dreams'`.
+- Imports `prisma` from `'@/lib/db'` and `revalidatePath` from `'next/cache'`. No other imports.
+- Returns `{ ok: false }` without any database call when `text` (trimmed) is empty or `field` is not one of the four allowed values.
+- Dispatches on `field` to exactly one create call: `likes` → `prisma.likesEntry.create` with `data: { profileId, text }`; `dislikes` → `prisma.dislikesEntry.create` with `data: { profileId, text }`; `jokes` → `prisma.joke.create` with `data: { profileId, text }`; `dreams` → `prisma.dream.create` with `data: { profileId, description: text }` — note the dreams field is `description`, NOT `text`; the trimmed input is used in all four.
+- Then `revalidatePath('/portrait')` and returns `{ ok: true }`.
+- `src/app/actions/addEntry.test.ts` mocks `'@/lib/db'` with `vi.mock('@/lib/db', () => ({ prisma: { likesEntry: { create: vi.fn() }, dislikesEntry: { create: vi.fn() }, joke: { create: vi.fn() }, dream: { create: vi.fn() } } }))` and `'next/cache'` with `vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }))`.
+- Test "creates a like": calls `addEntry('p1', 'likes', 'tea')`; asserts `{ ok: true }` and `prisma.likesEntry.create` called with `data: { profileId: 'p1', text: 'tea' }`.
+- Test "a dream stores description": calls `addEntry('p1', 'dreams', 'a cabin')`; asserts `prisma.dream.create` called with `data: { profileId: 'p1', description: 'a cabin' }` and that `prisma.likesEntry.create` was not called.
+- Test "unknown field is rejected": calls `addEntry('p1', 'moods' as never, 'x')`; asserts `{ ok: false }` and no create was called.
+- Test "empty text is rejected": calls `addEntry('p1', 'likes', '  ')`; asserts `{ ok: false }` and no create was called.
+
+**Testing:**
+- Test creates a like
+- Test a dream stores description
+- Test unknown field is rejected
+- Test empty text is rejected
+
+---
+
+## Story 13 — Mood entry form component
+
+**Depends on:** Story 11
+
+**Files to create:**
+- `src/components/MoodForm.tsx`
+- `src/components/MoodForm.test.tsx`
+
+**Acceptance Criteria:**
+- Default-exports a component named `MoodForm` — the SOLE export of `src/components/MoodForm.tsx`. The file's first line is the directive `'use client'`.
+- Props: `{ profileId: string }`. Imports `addMood` from `'@/app/actions/addMood'` and `useState` from `'react'`. No other imports.
+- Renders a text input labelled `Mood` (an accessible label association — `<label>` with `htmlFor` or wrapping), a text input labelled `Note`, and a button with the exact accessible name `Add mood`.
+- On submit, calls `addMood(profileId, label, note || null)` and clears both inputs when the result's `ok` is `true`; when `ok` is `false`, leaves the inputs as they are.
+- `src/components/MoodForm.test.tsx` mocks `'@/app/actions/addMood'` with `vi.mock('@/app/actions/addMood', () => ({ addMood: vi.fn() }))` — a server action is I/O and this is the file's ONLY mock. Imports `{ render, screen }` from `'@testing-library/react'` and `userEvent` (default) from `'@testing-library/user-event'`.
+- Test "submits the typed mood": mocks `addMood` resolving `{ ok: true }`; types `happy` into `Mood`, clicks `Add mood`; asserts `addMood` was called with `('p1', 'happy', null)`.
+- Test "clears the input after a successful add": same flow; asserts the `Mood` input's value is `''` afterwards.
+- Test "keeps the input when the action rejects it": mocks `addMood` resolving `{ ok: false }`; types `x`, submits; asserts the `Mood` input still has value `'x'`.
+
+**Testing:**
+- Test submits the typed mood
+- Test clears the input after a successful add
+- Test keeps the input when the action rejects it
+
+---
+
+## Story 14 — Entry form component
+
+**Depends on:** Story 12
+
+**Files to create:**
+- `src/components/EntryForm.tsx`
+- `src/components/EntryForm.test.tsx`
+
+**Acceptance Criteria:**
+- Default-exports a component named `EntryForm` — the SOLE export of `src/components/EntryForm.tsx`. The file's first line is the directive `'use client'`.
+- Props: `{ profileId: string }`. Imports `addEntry` and the type `EntryField` from `'@/app/actions/addEntry'` and `useState` from `'react'`. No other imports.
+- Renders a `<select>` labelled `Add to` with exactly four options whose values are `likes`, `dislikes`, `jokes`, `dreams` (in that order), a text input labelled `Entry`, and a button with the exact accessible name `Add entry`.
+- On submit, calls `addEntry(profileId, field, text)` with the selected field and typed text, and clears the text input when the result's `ok` is `true`.
+- `src/components/EntryForm.test.tsx` mocks `'@/app/actions/addEntry'` with `vi.mock('@/app/actions/addEntry', () => ({ addEntry: vi.fn() }))` — the file's ONLY mock. Imports `{ render, screen }` from `'@testing-library/react'` and `userEvent` (default) from `'@testing-library/user-event'`.
+- Test "submits to the selected field": mocks `addEntry` resolving `{ ok: true }`; selects `dreams`, types `a cabin`, clicks `Add entry`; asserts `addEntry` was called with `('p1', 'dreams', 'a cabin')`.
+- Test "defaults to likes": types `tea` and submits without touching the select; asserts `addEntry` was called with `('p1', 'likes', 'tea')`.
+- Test "clears the entry after success": asserts the `Entry` input's value is `''` after a successful submit.
+
+**Testing:**
+- Test submits to the selected field
+- Test defaults to likes
+- Test clears the entry after success
+
+---
+
+## Story 15 — Portrait view assembly
+
+**Depends on:** Story 7, Story 8, Story 9, Story 10, Story 13, Story 14
+
+**Files to create:**
+- `src/components/PortraitView.tsx`
+- `src/components/PortraitView.test.tsx`
+
+**Acceptance Criteria:**
+- Default-exports a component named `PortraitView` — the SOLE export of `src/components/PortraitView.tsx`.
+- Props: `{ portrait: Portrait; profileId: string; coverage: Coverage; daysSinceTouch: number | null; giftStats: GiftStats; buckets: MoodBucket[] }`. Imports the types from their modules (`Portrait` from `'@/lib/portrait/load'`, `Coverage` from `'@/lib/metrics/coverage'`, `GiftStats` from `'@/lib/metrics/gifts'`, `MoodBucket` from `'@/lib/metrics/moodBuckets'`) and the components `PortraitSection`, `MoodTimeline`, `StudyMetrics`, `GiftHistory`, `MoodForm`, `EntryForm` (all default imports from `'@/components/...'`). No hooks, no `'use client'` — the client boundary lives in the two form components.
+- Renders, in order: a heading containing `portrait.name`; `StudyMetrics`; a `PortraitSection` for each of Likes (`portrait.likes`), Dislikes (`portrait.dislikes`), Jokes (`portrait.jokes`), Dreams & wishes (`portrait.dreams`), Trips (`portrait.trips`); `GiftHistory` with `portrait.gifts`; `MoodTimeline` with `buckets`; `MoodForm` and `EntryForm` with `profileId`.
+- It is glue: it computes nothing and fetches nothing — every value renders from props.
+- `src/components/PortraitView.test.tsx` imports `{ render, screen }` from `'@testing-library/react'` and `PortraitView` (default). Does NOT use `vi.mock` — every child is a pure local component and the forms only call their actions on interaction, which these tests do not perform.
+- The test file declares one fixture portrait: `const portrait: Portrait = { name: 'Ada', likes: ['tea'], dislikes: [], jokes: [], dreams: [], moods: [], events: [], gifts: [], trips: [], occasions: [] }` and spreads it where variation is needed.
+- Test "renders the name and all sections": renders with the fixture and empty metrics (`coverage={{ filled: 1, total: 5, gaps: [] }}`, `daysSinceTouch={null}`, `giftStats={{ logged: 0, hits: 0, misses: 0, unrated: 0, successRate: null }}`, `buckets={[]}`); asserts `Ada` is present and `screen.getAllByTestId('portrait-section')` has length 5.
+- Test "wires the likes into their section": asserts text `tea` is present.
+- Test "renders both forms": asserts buttons named `Add mood` and `Add entry` are both present.
+
+**Testing:**
+- Test renders the name and all sections
+- Test wires the likes into their section
+- Test renders both forms
+
+---
+
+## Story 16 — Portrait page
+
+**Depends on:** Story 2, Story 15
+
+**Files to create:**
+- `src/app/portrait/page.tsx`
+- `src/app/portrait/page.test.tsx`
+
+**Acceptance Criteria:**
+- Default-exports an async server component named `PortraitPage` — and exports `const dynamic = 'force-dynamic'`. These are the SOLE exports of `src/app/portrait/page.tsx`.
+- Imports `getPortrait` from `'@/lib/portrait/load'`, `coverage` from `'@/lib/metrics/coverage'`, `daysSinceLastTouch` from `'@/lib/metrics/recency'`, `giftStats` from `'@/lib/metrics/gifts'`, `moodBuckets` from `'@/lib/metrics/moodBuckets'`, `PortraitView` (default) from `'@/components/PortraitView'`, and `prisma` from `'@/lib/db'`. No other imports.
+- Resolves the profile with `prisma.profile.findFirst()` (single-user app — the first profile is the profile). When there is none, or `getPortrait` returns `null`, renders a paragraph containing the exact text `No profile yet — start the questionnaire in Telegram.`
+- Otherwise computes: `coverage` from the portrait's list lengths under the keys `likes`, `dislikes`, `jokes`, `dreams`, `moods`, `events`, `gifts`, `trips` (in that order); `daysSinceLastTouch` over the mood `recordedAt`s and event `occurredAt`s combined, with `new Date()` as today — the page is the I/O shell, so the clock read belongs HERE, not in the metric; `giftStats` over the portrait's gifts; `moodBuckets` over the portrait's moods. Renders `PortraitView` with all of it.
+- `src/app/portrait/page.test.tsx` mocks `'@/lib/db'` with `vi.mock('@/lib/db', () => ({ prisma: { profile: { findFirst: vi.fn() } } }))` and `'@/lib/portrait/load'` with `vi.mock('@/lib/portrait/load', () => ({ getPortrait: vi.fn() }))` — both are I/O; the metrics and view are pure local modules and are NOT mocked. Renders the page by awaiting it: `render(await PortraitPage())`.
+- Test "renders the empty state without a profile": mocks `findFirst` resolving `null`; asserts the exact empty-state text is present and `getPortrait` was not called.
+- Test "renders the portrait for the first profile": mocks `findFirst` resolving `{ id: 'p1' }` and `getPortrait` resolving a minimal portrait (`name: 'Ada'`, all arrays empty); asserts `getPortrait` was called with `'p1'` and text `Ada` is present.
+- Test "computes coverage from the portrait": same mocks but `likes: ['tea']`; asserts text `1 of 8 areas filled` is present.
+
+**Testing:**
+- Test renders the empty state without a profile
+- Test renders the portrait for the first profile
+- Test computes coverage from the portrait
+
+---
+
+## Story 17 — Home page routes to the portrait
+
+**Depends on:** Story 16
+
+**Files to modify:**
+- `src/app/page.tsx`
+
+**Acceptance Criteria:**
+- Replaces the scaffold home page entirely: the new `src/app/page.tsx` imports `redirect` from `'next/navigation'` and default-exports a component named `Home` that calls `redirect('/portrait')`.
+- These are the SOLE contents: no JSX, no other imports, no other exports. The scaffold's `next/image` logo markup is deleted.
+
+**Testing:** not applicable — a one-line redirect with no branching; the portrait page's own tests cover the destination.


### PR DESCRIPTION
The two epic plans as source-of-truth docs. Epic 3 (#66–#82, 17 stories) applies epic 2's empirical rule by construction: pure modules compute, components render props, pages assemble — no unit carries more than two mocks, and the client boundary lives in exactly two leaf form components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgUuHL6M6pBwuwozBPFph3