### PR TITLE
feat(#77): Story 12 — Add-entry server action

### DIFF
--- a/src/app/actions/addEntry.test.ts
+++ b/src/app/actions/addEntry.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { addEntry, type EntryField } from './addEntry'
+import { prisma } from '@/lib/db'
+import { revalidatePath } from 'next/cache'
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    likesEntry: { create: vi.fn() },
+    dislikesEntry: { create: vi.fn() },
+    joke: { create: vi.fn() },
+    dream: { create: vi.fn() },
+  },
+}))
+
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+}))
+
+describe('addEntry', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('creates a like', async () => {
+    const res = await addEntry('p1', 'likes', 'tea')
+    
+    expect(res).toEqual({ ok: true })
+      expect(prisma.likesEntry.create).toHaveBeenCalledWith({
+      data: { profileId: 'p1', text: 'tea' },
+    })
+    expect(revalidatePath).toHaveBeenCalledWith('/portrait')
+  })
+
+  it('a dream stores description', async () => {
+    const res = await addEntry('p1', 'dreams', 'a cabin')
+
+    expect(res).toEqual({ ok: true })
+    expect(prisma.dream.create).toHaveBeenCalledWith({
+      data: { profileId: 'p1', description: 'a cabin' },
+    })
+    expect(prisma.likesEntry.create).not.toHaveBeenCalled()
+  })
+
+  it('unknown field is rejected', async () => {
+    // @ts-expect-error - testing runtime rejection of invalid field
+    const res = await addEntry('p1', 'moods', 'x')
+
+    expect(res).toEqual({ ok: false })
+    expect(prisma.likesEntry.create).not.toHaveBeenCalled()
+    expect(prisma.dislikesEntry.create).not.toHaveBeenCalled()
+    expect(prisma.joke.create).not.toHaveBeenCalled()
+    expect(prisma.dream.create).not.toHaveBeenCalled()
+  })
+
+  it('empty text is rejected', async () => {
+    const res = await addEntry('p1', 'likes', '  ')
+
+    expect(res).toEqual({ ok: false })
+    expect(prisma.likesEntry.create).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/actions/addEntry.ts
+++ b/src/app/actions/addEntry.ts
@@ -1,0 +1,32 @@
+'use server'
+
+import { prisma } from '@/lib/db'
+import { revalidatePath } from 'next/cache'
+
+const FIELDS = ['likes', 'dislikes', 'jokes', 'dreams'] as const
+export type EntryField = typeof FIELDS[number]
+
+export async function addEntry(
+  profileId: string,
+  field: EntryField,
+  text: string
+): Promise<{ ok: boolean }> {
+  const trimmedText = text.trim()
+
+  if (!trimmedText || !FIELDS.includes(field)) {
+    return { ok: false }
+  }
+
+  if (field === 'likes') {
+    await prisma.likesEntry.create({ data: { profileId, text: trimmedText } })
+  } else if (field === 'dislikes') {
+    await prisma.dislikesEntry.create({ data: { profileId, text: trimmedText } })
+  } else if (field === 'jokes') {
+    await prisma.joke.create({ data: { profileId, text: trimmedText } })
+  } else if (field === 'dreams') {
+    await prisma.dream.create({ data: { profileId, description: trimmedText } })
+  }
+
+  revalidatePath('/portrait')
+  return { ok: true }
+}


### PR DESCRIPTION
## Summary

Implements story #77: Story 12 — Add-entry server action

## Verified gates (auto-captured by dag-poc)

- `smoke` exit 0
- `typecheck` exit 0
- `lint` exit 0

## Implementation provenance

- Model: `spike-coder-v3:latest` (local Ollama)
- LLM calls: 3
- Prompt tokens: 22475
- Output tokens: 5447

Closes #77

Co-Authored-By: gemma4:26b (Spike coder) <noreply@spike.local>

## Verified gates *(auto-captured by spike-guard)*

- build: ✓ exit 0 (run at 2026-08-18T22:45:02Z)
- lint: ✓ exit 0 (run at 2026-08-18T22:45:59Z)
- test: ✓ exit 0 (run at 2026-08-18T22:45:59Z)
