### PR TITLE
feat(#76): Story 11 — Add-mood server action

### DIFF
--- a/src/app/actions/addMood.test.ts
+++ b/src/app/actions/addMood.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { addMood } from './addMood'
+import { prisma as db } from '@/lib/db'
+import { revalidatePath } from 'next/cache'
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    mood: {
+      create: vi.fn(),
+    },
+  },
+}))
+
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+}))
+
+describe('addMood', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('creates the mood and revalidates', async () => {
+    vi.mocked(db.mood.create).mockResolvedValue({} as any)
+
+    const result = await addMood('p1', 'happy', null)
+
+    expect(result).toEqual({ ok: true })
+    expect(db.mood.create).toHaveBeenCalledWith({
+      data: {
+        profileId: 'p1',
+        label: 'happy',
+        note: null,
+      },
+    })
+    expect(revalidatePath).toHaveBeenCalledWith('/portrait')
+  })
+
+  it('empty label is rejected without a db call', async () => {
+    const result = await addMood('p1', '   ', null)
+
+    expect(result).toEqual({ ok: false })
+    expect(db.mood.create).not.toHaveBeenCalled()
+  })
+
+  it('label is trimmed', async () => {
+    vi.mocked(db.mood.create).mockResolvedValue({} as any)
+
+    await addMood('p1', '  calm ', 'after dinner')
+
+    expect(db.mood.create).toHaveBeenCalledWith({
+      data: {
+        profileId: 'p1',
+        label: 'calm',
+        note: 'after dinner',
+      },
+    })
+  })
+})

--- a/src/app/actions/addMood.ts
+++ b/src/app/actions/addMood.ts
@@ -1,0 +1,28 @@
+'use server'
+
+import { prisma } from '@/lib/db'
+import { revalidatePath } from 'next/cache'
+
+export async function addMood(
+  profileId: string,
+  label: string,
+  note: string | null
+): Promise<{ ok: boolean }> {
+  const trimmedLabel = label.trim()
+
+  if (!trimmedLabel) {
+    return { ok: false }
+  }
+
+  await prisma.mood.create({
+    data: {
+      profileId,
+      label: trimmedLabel,
+      note,
+    },
+  })
+
+  revalidatePath('/portrait')
+
+  return { ok: true }
+}


### PR DESCRIPTION
## Summary

Implements story #76: Story 11 — Add-mood server action

## Verified gates (auto-captured by dag-poc)

- `lint` exit 0
- `build` exit 0
- `smoke` exit 0

## Implementation provenance

- Model: `spike-coder-v3:latest` (local Ollama)
- LLM calls: 2
- Prompt tokens: 13652
- Output tokens: 684

Closes #76

Co-Authored-By: gemma4:26b (Spike coder) <noreply@spike.local>

## Verified gates *(auto-captured by spike-guard)*

- build: ✓ exit 0 (run at 2026-08-18T22:46:42Z)
- lint: ✓ exit 0 (run at 2026-08-18T22:46:38Z)
- test: ✓ exit 0 (run at 2026-08-18T22:46:39Z)
