### PR TITLE
feat(#81): Story 16 — Portrait page (hand-written)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -82,6 +82,7 @@ model Gift {
   profileId   String
   description String
   givenAt     DateTime?
+  howItLanded String?
   createdAt   DateTime  @default(now())
   profile     Profile   @relation(fields: [profileId], references: [id], onDelete: Cascade)
 }

--- a/src/app/actions/addEntry.test.ts
+++ b/src/app/actions/addEntry.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { addEntry, type EntryField } from './addEntry'
+import { prisma } from '@/lib/db'
+import { revalidatePath } from 'next/cache'
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    likesEntry: { create: vi.fn() },
+    dislikesEntry: { create: vi.fn() },
+    joke: { create: vi.fn() },
+    dream: { create: vi.fn() },
+  },
+}))
+
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+}))
+
+describe('addEntry', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('creates a like', async () => {
+    const res = await addEntry('p1', 'likes', 'tea')
+    
+    expect(res).toEqual({ ok: true })
+      expect(prisma.likesEntry.create).toHaveBeenCalledWith({
+      data: { profileId: 'p1', text: 'tea' },
+    })
+    expect(revalidatePath).toHaveBeenCalledWith('/portrait')
+  })
+
+  it('a dream stores description', async () => {
+    const res = await addEntry('p1', 'dreams', 'a cabin')
+
+    expect(res).toEqual({ ok: true })
+    expect(prisma.dream.create).toHaveBeenCalledWith({
+      data: { profileId: 'p1', description: 'a cabin' },
+    })
+    expect(prisma.likesEntry.create).not.toHaveBeenCalled()
+  })
+
+  it('unknown field is rejected', async () => {
+    // @ts-expect-error - testing runtime rejection of invalid field
+    const res = await addEntry('p1', 'moods', 'x')
+
+    expect(res).toEqual({ ok: false })
+    expect(prisma.likesEntry.create).not.toHaveBeenCalled()
+    expect(prisma.dislikesEntry.create).not.toHaveBeenCalled()
+    expect(prisma.joke.create).not.toHaveBeenCalled()
+    expect(prisma.dream.create).not.toHaveBeenCalled()
+  })
+
+  it('empty text is rejected', async () => {
+    const res = await addEntry('p1', 'likes', '  ')
+
+    expect(res).toEqual({ ok: false })
+    expect(prisma.likesEntry.create).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/actions/addEntry.ts
+++ b/src/app/actions/addEntry.ts
@@ -1,0 +1,32 @@
+'use server'
+
+import { prisma } from '@/lib/db'
+import { revalidatePath } from 'next/cache'
+
+const FIELDS = ['likes', 'dislikes', 'jokes', 'dreams'] as const
+export type EntryField = typeof FIELDS[number]
+
+export async function addEntry(
+  profileId: string,
+  field: EntryField,
+  text: string
+): Promise<{ ok: boolean }> {
+  const trimmedText = text.trim()
+
+  if (!trimmedText || !FIELDS.includes(field)) {
+    return { ok: false }
+  }
+
+  if (field === 'likes') {
+    await prisma.likesEntry.create({ data: { profileId, text: trimmedText } })
+  } else if (field === 'dislikes') {
+    await prisma.dislikesEntry.create({ data: { profileId, text: trimmedText } })
+  } else if (field === 'jokes') {
+    await prisma.joke.create({ data: { profileId, text: trimmedText } })
+  } else if (field === 'dreams') {
+    await prisma.dream.create({ data: { profileId, description: trimmedText } })
+  }
+
+  revalidatePath('/portrait')
+  return { ok: true }
+}

--- a/src/app/actions/addMood.test.ts
+++ b/src/app/actions/addMood.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { addMood } from './addMood'
+import { prisma as db } from '@/lib/db'
+import { revalidatePath } from 'next/cache'
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    mood: {
+      create: vi.fn(),
+    },
+  },
+}))
+
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+}))
+
+describe('addMood', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('creates the mood and revalidates', async () => {
+    vi.mocked(db.mood.create).mockResolvedValue({} as any)
+
+    const result = await addMood('p1', 'happy', null)
+
+    expect(result).toEqual({ ok: true })
+    expect(db.mood.create).toHaveBeenCalledWith({
+      data: {
+        profileId: 'p1',
+        label: 'happy',
+        note: null,
+      },
+    })
+    expect(revalidatePath).toHaveBeenCalledWith('/portrait')
+  })
+
+  it('empty label is rejected without a db call', async () => {
+    const result = await addMood('p1', '   ', null)
+
+    expect(result).toEqual({ ok: false })
+    expect(db.mood.create).not.toHaveBeenCalled()
+  })
+
+  it('label is trimmed', async () => {
+    vi.mocked(db.mood.create).mockResolvedValue({} as any)
+
+    await addMood('p1', '  calm ', 'after dinner')
+
+    expect(db.mood.create).toHaveBeenCalledWith({
+      data: {
+        profileId: 'p1',
+        label: 'calm',
+        note: 'after dinner',
+      },
+    })
+  })
+})

--- a/src/app/actions/addMood.ts
+++ b/src/app/actions/addMood.ts
@@ -1,0 +1,28 @@
+'use server'
+
+import { prisma } from '@/lib/db'
+import { revalidatePath } from 'next/cache'
+
+export async function addMood(
+  profileId: string,
+  label: string,
+  note: string | null
+): Promise<{ ok: boolean }> {
+  const trimmedLabel = label.trim()
+
+  if (!trimmedLabel) {
+    return { ok: false }
+  }
+
+  await prisma.mood.create({
+    data: {
+      profileId,
+      label: trimmedLabel,
+      note,
+    },
+  })
+
+  revalidatePath('/portrait')
+
+  return { ok: true }
+}

--- a/src/app/portrait/page.test.tsx
+++ b/src/app/portrait/page.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { prisma } from '@/lib/db'
+import { getPortrait, type Portrait } from '@/lib/portrait/load'
+import PortraitPage from './page'
+
+vi.mock('@/lib/db', () => ({
+  prisma: { profile: { findFirst: vi.fn() } },
+}))
+vi.mock('@/lib/portrait/load', () => ({ getPortrait: vi.fn() }))
+// The metrics and PortraitView are pure local modules — NOT mocked; the page
+// test proves the real wiring end to end.
+
+const empty: Portrait = {
+  name: 'Ada',
+  likes: [],
+  dislikes: [],
+  jokes: [],
+  dreams: [],
+  moods: [],
+  events: [],
+  gifts: [],
+  trips: [],
+  occasions: [],
+}
+
+describe('PortraitPage', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('renders the empty state without a profile', async () => {
+    vi.mocked(prisma.profile.findFirst).mockResolvedValue(null)
+
+    render(await PortraitPage())
+
+    expect(
+      screen.getByText('No profile yet — start the questionnaire in Telegram.')
+    ).toBeInTheDocument()
+    expect(getPortrait).not.toHaveBeenCalled()
+  })
+
+  it('renders the portrait for the first profile', async () => {
+    vi.mocked(prisma.profile.findFirst).mockResolvedValue({ id: 'p1' } as never)
+    vi.mocked(getPortrait).mockResolvedValue(empty)
+
+    render(await PortraitPage())
+
+    expect(getPortrait).toHaveBeenCalledWith('p1')
+    expect(screen.getByText('Ada')).toBeInTheDocument()
+  })
+
+  it('computes coverage from the portrait', async () => {
+    vi.mocked(prisma.profile.findFirst).mockResolvedValue({ id: 'p1' } as never)
+    vi.mocked(getPortrait).mockResolvedValue({ ...empty, likes: ['tea'] })
+
+    render(await PortraitPage())
+
+    expect(screen.getByText('1 of 8 areas filled')).toBeInTheDocument()
+  })
+})

--- a/src/app/portrait/page.tsx
+++ b/src/app/portrait/page.tsx
@@ -1,0 +1,47 @@
+import { prisma } from '@/lib/db'
+import { getPortrait } from '@/lib/portrait/load'
+import { coverage } from '@/lib/metrics/coverage'
+import { daysSinceLastTouch } from '@/lib/metrics/recency'
+import { giftStats } from '@/lib/metrics/gifts'
+import { moodBuckets } from '@/lib/metrics/moodBuckets'
+import PortraitView from '@/components/PortraitView'
+
+export const dynamic = 'force-dynamic'
+
+export default async function PortraitPage() {
+  // Single-user app: the first profile is the profile.
+  const profile = await prisma.profile.findFirst()
+  const portrait = profile ? await getPortrait(profile.id) : null
+  if (!profile || !portrait) {
+    return <p>No profile yet — start the questionnaire in Telegram.</p>
+  }
+
+  const cov = coverage({
+    likes: portrait.likes.length,
+    dislikes: portrait.dislikes.length,
+    jokes: portrait.jokes.length,
+    dreams: portrait.dreams.length,
+    moods: portrait.moods.length,
+    events: portrait.events.length,
+    gifts: portrait.gifts.length,
+    trips: portrait.trips.length,
+  })
+  // The page is the I/O shell, so the clock read belongs here, not in the
+  // metric.
+  const touches = [
+    ...portrait.moods.map((m) => m.recordedAt),
+    ...portrait.events.map((e) => e.occurredAt),
+  ]
+  const daysSinceTouch = daysSinceLastTouch(touches, new Date())
+
+  return (
+    <PortraitView
+      portrait={portrait}
+      profileId={profile.id}
+      coverage={cov}
+      daysSinceTouch={daysSinceTouch}
+      giftStats={giftStats(portrait.gifts)}
+      buckets={moodBuckets(portrait.moods)}
+    />
+  )
+}

--- a/src/components/EntryForm.test.tsx
+++ b/src/components/EntryForm.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import EntryForm from './EntryForm'
+import { addEntry } from '@/app/actions/addEntry'
+
+vi.mock('@/app/actions/addEntry', () => ({ addEntry: vi.fn() }))
+
+describe('EntryForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('submits to the selected field', async () => {
+    const user = userEvent.setup()
+    vi.mocked(addEntry).mockResolvedValue({ ok: true })
+    
+    render(<EntryForm profileId="p1" />)
+    
+    const select = screen.getByLabelText('Add to')
+    const input = screen.getByLabelText('Entry')
+    const button = screen.getByRole('button', { name: 'Add entry' })
+
+    await user.selectOptions(select, 'dreams')
+    await user.type(input, 'a cabin')
+    await user.click(button)
+
+    expect(addEntry).toHaveBeenCalledWith('p1', 'dreams', 'a cabin')
+  })
+
+  it('defaults to likes', async () => {
+    const user = userEvent.setup()
+    vi.mocked(addEntry).mockResolvedValue({ ok: true })
+    
+    render(<EntryForm profileId="p1" />)
+    
+    const input = screen.getByLabelText('Entry')
+    const button = screen.getByRole('button', { name: 'Add entry' })
+
+    await user.type(input, 'tea')
+    await user.click(button)
+
+    expect(addEntry).toHaveBeenCalledWith('p1', 'likes', 'tea')
+  })
+
+  it('clears the entry after success', async () => {
+    const user = userEvent.setup()
+    vi.mocked(addEntry).mockResolvedValue({ ok: true })
+    
+    render(<EntryForm profileId="p1" />)
+    
+    const input = screen.getByLabelText('Entry')
+    const button = screen.getByRole('button', { name: 'Add entry' })
+
+    await user.type(input, 'some text')
+    await user.click(button)
+
+    await expect(input).toHaveValue('')
+  })
+})

--- a/src/components/EntryForm.tsx
+++ b/src/components/EntryForm.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import { useState } from 'react'
+import { addEntry, type EntryField } from '@/app/actions/addEntry'
+
+export default function EntryForm({ profileId }: { profileId: string }) {
+  const [field, setField] = useState<EntryField>('likes')
+  const [text, setText] = useState('')
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const result = await addEntry(profileId, field, text)
+    if (result.ok) {
+      setText('')
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label htmlFor="field-select" className="block text-sm font-medium text-gray-700">
+          Add to
+        </label>
+        <select
+          id="field-select"
+          value={field}
+          onChange={(e) => setField(e.target.value as EntryField)}
+          className="mt-1 block w-full rounded-md border border-gray-300 py-2 px-3 shadow-sm focus:border-emerald-500 focus:ring-emerald-500"
+        >
+          <option value="likes">likes</option>
+          <option value="dislikes">dislikes</option>
+          <option value="jokes">jokes</option>
+          <option value="dreams">dreams</option>
+        </select>
+      </div>
+
+      <div>
+        <label htmlFor="entry-text" className="block text-sm font-medium text-gray-700">
+          Entry
+        </label>
+        <input
+          id="entry-text"
+          type="text"
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          className="mt-1 block w-full rounded-md border border-gray-300 py-2 px-3 shadow-sm focus:border-emerald-500 focus:ring-emerald-500"
+        />
+      </div>
+
+      <button
+        type="submit"
+        className="rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-700 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2"
+      >
+        Add entry
+      </button>
+    </form>
+  )
+}

--- a/src/components/GiftHistory.test.tsx
+++ b/src/components/GiftHistory.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import GiftHistory from './GiftHistory'
+
+describe('GiftHistory', () => {
+  it('renders each gift with its outcome', () => {
+    render(
+      <GiftHistory
+        gifts={[
+          { description: 'a record player', givenAt: null, howItLanded: 'hit' },
+          { description: 'socks', givenAt: null, howItLanded: null },
+        ]}
+      />
+    )
+
+    const outcomes = screen.getAllByTestId('gift-outcome')
+    expect(outcomes).toHaveLength(2)
+    expect(outcomes[0]).toHaveTextContent('landed')
+    expect(outcomes[1]).toHaveTextContent('unrated')
+    expect(screen.getByText('a record player')).toBeInTheDocument()
+  })
+
+  it('empty history shows the placeholder', () => {
+    render(<GiftHistory gifts={[]} />)
+
+    expect(screen.getByText('No gifts logged yet.')).toBeInTheDocument()
+    expect(screen.queryByRole('list')).toBeNull()
+  })
+})

--- a/src/components/GiftHistory.tsx
+++ b/src/components/GiftHistory.tsx
@@ -1,0 +1,29 @@
+type Gift = {
+  description: string
+  givenAt: Date | null
+  howItLanded: string | null
+}
+
+function outcome(howItLanded: string | null): string {
+  if (howItLanded === 'hit') return 'landed'
+  if (howItLanded === 'miss') return 'missed'
+  return 'unrated'
+}
+
+export default function GiftHistory({ gifts }: { gifts: Gift[] }) {
+  if (gifts.length === 0) {
+    return <p>No gifts logged yet.</p>
+  }
+  return (
+    <ul className="space-y-2">
+      {gifts.map((gift, i) => (
+        <li key={i} className="flex items-center justify-between gap-2 text-sm">
+          <span>{gift.description}</span>
+          <span data-testid="gift-outcome" className="rounded-full bg-zinc-100 px-2 py-0.5 text-xs">
+            {outcome(gift.howItLanded)}
+          </span>
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/src/components/MoodForm.test.tsx
+++ b/src/components/MoodForm.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import MoodForm from './MoodForm'
+
+vi.mock('@/app/actions/addMood', () => ({ addMood: vi.fn() }))
+
+describe('MoodForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('submits the typed mood', async () => {
+    const { addMood } = await import('@/app/actions/addMood')
+    vi.mocked(addMood).mockResolvedValue({ ok: true })
+    const user = userEvent.setup()
+    
+    render(<MoodForm profileId="p1" />)
+    
+    const moodInput = screen.getByLabelText('Mood')
+    const submitButton = screen.getByRole('button', { name: 'Add mood' })
+
+    await user.type(moodInput, 'happy')
+    await user.click(submitButton)
+
+    expect(addMood).toHaveBeenCalledWith('p1', 'happy', null)
+  })
+
+  it('clears the input after a successful add', async () => {
+    const { addMood } = await import('@/app/actions/addMood')
+    vi.mocked(addMood).mockResolvedValue({ ok: true })
+    const user = userEvent.setup()
+    
+    render(<MoodForm profileId="p1" />)
+    
+    const moodInput = screen.getByLabelText('Mood')
+    const submitButton = screen.getByRole('button', { name: 'Add mood' })
+
+    await user.type(moodInput, 'happy')
+    await user.click(submitButton)
+
+    expect(moodInput).toHaveValue('')
+  })
+
+  it('keeps the input when the action rejects it', async () => {
+    const { addMood } = await import('@/app/actions/addMood')
+    vi.mocked(addMood).mockResolvedValue({ ok: false })
+    const user = userEvent.setup()
+    
+    render(<MoodForm profileId="p1" />)
+    
+    const moodInput = screen.getByLabelText('Mood')
+    const submitButton = screen.getByRole('button', { name: 'Add mood' })
+
+    await user.type(moodInput, 'x')
+    await user.click(submitButton)
+
+    expect(moodInput).toHaveValue('x')
+  })
+})

--- a/src/components/MoodForm.tsx
+++ b/src/components/MoodForm.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import { useState } from 'react'
+import { addMood } from '@/app/actions/addMood'
+
+interface MoodFormProps {
+  profileId: string
+}
+
+export default function MoodForm({ profileId }: MoodFormProps) {
+  const [label, setLabel] = useState('')
+  const [note, setNote] = useState('')
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const result = await addMood(profileId, label, note || null)
+    if (result.ok) {
+      setLabel('')
+      setNote('')
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="flex flex-col gap-1">
+        <label htmlFor="mood-input" className="text-sm font-medium">
+          Mood
+        </label>
+        <input
+          id="mood-input"
+          type="text"
+          value={label}
+          onChange={(e) => setLabel(e.target.value)}
+          className="rounded-md border border-gray-300 px-3 py-2 text-sm"
+          required
+        />
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <label htmlFor="note-input" className="text-sm font-medium">
+          Note
+        </label>
+        <input
+          id="note-input"
+          type="text"
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+          className="rounded-md border border-gray-300 px-3 py/2 text-sm"
+        />
+      </div>
+
+      <button
+        type="submit"
+        className="rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-700"
+      >
+        Add mood
+      </button>
+    </form>
+  )
+}

--- a/src/components/MoodTimeline.test.tsx
+++ b/src/components/MoodTimeline.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import MoodTimeline from './MoodTimeline'
+
+describe('MoodTimeline', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders one row per day', async () => {
+    const buckets = [
+      { day: '2026-08-17', labels: ['happy'] },
+      { day: '2026-08-18', labels: ['sad'] },
+    ]
+    render(<MoodTimeline buckets={buckets} />)
+    expect(screen.getAllByTestId('mood-day')).toHaveLength(2)
+  })
+
+  it('shows the day and its labels', async () => {
+    const buckets = [
+      { day: '2026-08-17', labels: ['happy', 'tired'] },
+    ]
+    render(<MoodTimeline buckets={buckets} />)
+    expect(screen.getByText('2026-08-17')).toBeInTheDocument()
+    expect(screen.getByText('happy')).toBeInTheDocument()
+    expect(screen.getByText('tired')).toBeInTheDocument()
+  })
+
+  it('empty timeline shows the placeholder', async () => {
+    render(<MoodTimeline buckets={[]} />)
+    expect(screen.getByText('No moods recorded yet.')).toBeInTheDocument()
+  })
+})

--- a/src/components/MoodTimeline.tsx
+++ b/src/components/MoodTimeline.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import type { MoodBucket } from '@/lib/metrics/moodBuckets';
+
+interface MoodTimelineProps {
+  buckets: MoodBucket[];
+}
+
+export default function MoodTimeline({ buckets }: MoodTimelineProps) {
+  if (buckets.length === 0) {
+    return <p>No moods recorded yet.</p>;
+  }
+
+  return (
+    <div className="space-y-4">
+      {buckets.map((bucket) => (
+        <div
+          key={bucket.day}
+          data-testid="mood-day"
+          className="flex items-center gap-4 border-b border-slate-200 pb-2"
+        >
+          <span className="font-medium text-slate-900 min-w-[100px]">
+            {bucket.day}
+          </span>
+          <div className="flex flex-wrap gap-2">
+            {bucket.labels.map((label) => (
+              <span
+                key={label}
+                className="rounded-full bg-slate-100 px-2.5 py-0.5 text-xs font-medium text-slate-800"
+              >
+                {label}
+              </span>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/PortraitSection.test.tsx
+++ b/src/components/PortraitSection.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import PortraitSection from './PortraitSection'
+
+describe('PortraitSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the title and items', async () => {
+    render(<PortraitSection title="Likes" items={['tea', 'rain']} />)
+    expect(screen.getByText('Likes')).toBeInTheDocument()
+    expect(screen.getAllByRole('listitem')).toHaveLength(2)
+  })
+
+  it('empty items show the placeholder', async () => {
+    render(<PortraitSection title="Dislikes" items={[]} />)
+    expect(screen.getByText('Nothing here yet.')).toBeInTheDocument()
+    expect(screen.queryByRole('list')).toBeNull()
+  })
+})

--- a/src/components/PortraitSection.tsx
+++ b/src/components/PortraitSection.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+interface PortraitSectionProps {
+  title: string;
+  items: string[];
+}
+
+export default function PortraitSection({ title, items }: PortraitSectionProps) {
+  return (
+    <section data-testid="portrait-section" className="space-y-4">
+      <h2 className="text-xl font-semibold text-gray-900">{title}</h2>
+      {items.length > 0 ? (
+        <ul className="list-disc pl-5 space-y-2 text-gray-700">
+          {items.map((item, index) => (
+            <li key={index}>{item}</li>
+          ))}
+        </ul>
+      ) : (
+        <p className="text-gray-500 italic">Nothing here yet.</p>
+      )}
+    </section>
+  );
+}

--- a/src/components/PortraitView.test.tsx
+++ b/src/components/PortraitView.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import PortraitView from './PortraitView'
+import type { Portrait } from '@/lib/portrait/load'
+import type { Coverage } from '@/lib/metrics/coverage'
+import type { GiftStats } from '@/lib/metrics/gifts'
+import type { MoodBucket } from '@/lib/metrics/moodBuckets'
+
+describe('PortraitView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the name and all sections', async () => {
+    const portrait: Portrait = {
+      name: 'Ada',
+      likes: ['tea'],
+      dislikes: [],
+      jokes: [],
+      dreams: [],
+      trips: [],
+      gifts: [],
+      moods: [],
+      events: [],
+      occasions: []
+    }
+    const coverage: Coverage = { filled: 1, total: 5, gaps: [] }
+    const giftStats: GiftStats = { logged: 0, hits: 0, misses: 0, unrated: 0, successRate: null }
+    const buckets: MoodBucket[] = []
+
+    render(
+      <PortraitView
+        portrait={portrait}
+        profileId="p1"
+        coverage={coverage}
+        daysSinceTouch={null}
+        giftStats={giftStats}
+        buckets={buckets}
+      />
+    )
+
+    expect(screen.getByText('Ada')).toBeInTheDocument()
+    expect(screen.getAllByTestId('portrait-section')).toHaveLength(5)
+  })
+
+  it('wires the likes into their section', async () => {
+    const portrait: Portrait = {
+      name: 'Ada',
+      likes: ['tea'],
+      dislikes: [],
+      jokes: [],
+      dreams: [],
+      trips: [],
+      gifts: [],
+      moods: [],
+      events: [],
+      occasions: []
+    }
+    const coverage: Coverage = { filled: 1, total: 5, gaps: [] }
+    const giftStats: GiftStats = { logged: 0, hits: 0, misses: 0, unrated: 0, successRate: null }
+    const buckets: MoodBucket[] = []
+
+    render(
+      <PortraitView
+        portrait={portrait}
+        profileId="p1"
+        coverage={coverage}
+        daysSinceTouch={null}
+        giftStats={giftStats}
+        buckets={buckets}
+      />
+    )
+
+    expect(screen.getByText('tea')).toBeInTheDocument()
+  })
+
+  it('renders both forms', async () => {
+    const portrait: Portrait = {
+      name: 'Ada',
+      likes: [],
+      dislikes: [],
+      jokes: [],
+      dreams: [],
+      trips: [],
+      gifts: [],
+      moods: [],
+      events: [],
+      occasions: []
+    }
+    const coverage: Coverage = { filled: 1, total: 5, gaps: [] }
+    const giftStats: GiftStats = { logged: 0, hits: 0, misses: 0, unrated: 0, successRate: null }
+    const buckets: MoodBucket[] = []
+
+    render(
+      <PortraitView
+        portrait={portrait}
+        profileId="p1"
+        coverage={coverage}
+        daysSinceTouch={null}
+        giftStats={giftStats}
+        buckets={buckets}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: 'Add mood' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Add entry' })).toBeInTheDocument()
+  })
+})

--- a/src/components/PortraitView.tsx
+++ b/src/components/PortraitView.tsx
@@ -1,0 +1,57 @@
+import type { Portrait } from '@/lib/portrait/load';
+import type { Coverage } from '@/lib/metrics/coverage';
+import type { GiftStats } from '@/lib/metrics/gifts';
+import type { MoodBucket } from '@/lib/metrics/moodBuckets';
+import PortraitSection from '@/components/PortraitSection';
+import MoodTimeline from '@/components/MoodTimeline';
+import StudyMetrics from '@/components/StudyMetrics';
+import GiftHistory from '@/components/GiftHistory';
+import MoodForm from '@/components/MoodForm';
+import EntryForm from '@/components/EntryForm';
+
+interface PortraitViewProps {
+  portrait: Portrait;
+  profileId: string;
+  coverage: Coverage;
+  daysSinceTouch: number | null;
+  giftStats: GiftStats;
+  buckets: MoodBucket[];
+}
+
+export default function PortraitView({
+  portrait,
+  profileId,
+  coverage,
+  daysSinceTouch,
+  giftStats,
+  buckets,
+}: PortraitViewProps) {
+  return (
+    <div className="space-y-8">
+      <h1 className="text-3xl font-bold text-gray-900">{portrait.name}</h1>
+
+      <StudyMetrics
+        coverage={coverage}
+        daysSinceTouch={daysSinceTouch}
+        gifts={giftStats}
+      />
+
+      <div className="space-y-4">
+        <PortraitSection title="Likes" items={portrait.likes} />
+        <PortraitSection title="Dislikes" items={portrait.dislikes} />
+        <PortraitSection title="Jokes" items={portrait.jokes} />
+        <PortraitSection title="Dreams & Wishes" items={portrait.dreams} />
+        <PortraitSection title="Trips" items={portrait.trips} />
+      </div>
+
+      <GiftHistory gifts={portrait.gifts} />
+
+      <MoodTimeline buckets={buckets} />
+
+      <div className="grid grid-cols-1 gap-8 md:grid-cols-2">
+        <MoodForm profileId={profileId} />
+        <EntryForm profileId={profileId} />
+      </div>
+    </div>
+  );
+}

--- a/src/components/StudyMetrics.test.tsx
+++ b/src/components/StudyMetrics.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import StudyMetrics from './StudyMetrics'
+
+describe('StudyMetrics', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows coverage and gaps', async () => {
+    const coverage = { filled: 2, total: 3, gaps: ['jokes'] }
+    const gifts = { logged: 1, hits: 1, misses: 0, unrated: 0, successRate: 1.0 }
+    
+    render(<StudyMetrics coverage={coverage} daysSinceTouch={1} gifts={gifts} />)
+    
+    expect(screen.getByText('2 of 3 areas filled')).toBeInTheDocument()
+    expect(screen.getByTestId('coverage-gap')).toHaveTextContent('jokes')
+  })
+
+  it('shows recency in days', async () => {
+    const coverage = { filled: 1, total: 1, gaps: [] }
+    const gifts = { logged: 1, hits: 1, misses: 0, unrated: 0, successRate: 1.0 }
+    
+    render(<StudyMetrics coverage={coverage} daysSinceTouch={5} gifts={gifts} />)
+    
+    expect(screen.getByText('Updated 5 days ago')).toBeInTheDocument()
+  })
+
+  it('never updated and no rated gifts', async () => {
+    const coverage = { filled: 0, total: 1, gaps: [] }
+    const gifts = { logged: 1, hits: 0, misses: 0, unrated: 1, successRate: null }
+    
+    render(<StudyMetrics coverage={coverage} daysSinceTouch={null} gifts={gifts} />)
+    
+    expect(screen.getByText('Never updated')).toBeInTheDocument()
+    expect(screen.getByText('No gifts rated yet')).toBeInTheDocument()
+  })
+})

--- a/src/components/StudyMetrics.tsx
+++ b/src/components/StudyMetrics.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import type { Coverage } from '@/lib/metrics/coverage';
+import type { GiftStats } from '@/lib/metrics/gifts';
+
+interface StudyMetricsProps {
+  coverage: Coverage;
+  daysSinceTouch: number | null;
+  gifts: GiftStats;
+}
+
+const Recency = ({ days }: { days: number | null }) => {
+  if (days === null) return <span>Never updated</span>;
+  if (days === 0) return <span>Updated today</span>;
+  return <span>Updated {days} days ago</span>;
+};
+
+const Gifts = ({ stats }: { stats: GiftStats }) => {
+  if (stats.successRate === null) return <span>No gifts rated yet</span>;
+  const rated = stats.hits + stats.misses;
+  return <span>{stats.hits} of {rated} gifts landed</span>;
+};
+
+export default function StudyMetrics({ coverage, daysSinceTouch, gifts }: StudyMetricsProps) {
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <p className="text-sm font-medium text-slate-900">Coverage</p>
+        <p className="text-sm text-slate-600">
+          {coverage.filled} of {coverage.total} areas filled
+        </p>
+        {coverage.gaps.map((gap) => (
+          <div key={gap} data-testid="coverage-gap" className="text-xs text-red-600">
+            {gap}
+          </div>
+        ))}
+      </div>
+
+      <div className="space-y-2">
+        <p className="text-sm font-medium text-slate-900">Recency</p>
+        <Recency days={daysSinceTouch} />
+      </div>
+
+      <div className="space-y-2">
+        <p className="text-sm font-medium text-slate-900">Gifts</p>
+        <Gifts stats={gifts} />
+      </div>
+    </div>
+  );
+}

--- a/src/lib/metrics/coverage.test.ts
+++ b/src/lib/metrics/coverage.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { coverage } from './coverage'
+
+describe('coverage', () => {
+  it('counts filled and total', () => {
+    const input = { likes: 3, dislikes: 0, jokes: 1 }
+    const result = coverage(input)
+    expect(result).toEqual({
+      filled: 2,
+      total: 3,
+      gaps: ['dislikes'],
+    })
+  })
+
+  it('all filled means no gaps', () => {
+    const input = { likes: 1, jokes: 2 }
+    const result = coverage(input)
+    expect(result.gaps).toEqual([])
+    expect(result.filled).toBe(2)
+    expect(result.total).toBe(2)
+  })
+
+  it('empty input is empty coverage', () => {
+    const input = {}
+    const result = coverage(input)
+    expect(result).toEqual({
+      filled: 0,
+      total: 0,
+      gaps: [],
+    })
+  })
+})

--- a/src/lib/metrics/coverage.ts
+++ b/src/lib/metrics/coverage.ts
@@ -1,0 +1,26 @@
+export type Coverage = {
+  filled: number;
+  total: number;
+  gaps: string[];
+};
+
+export function coverage(counts: Record<string, number>): Coverage {
+  const keys = Object.keys(counts);
+  const total = keys.length;
+  const gaps: string[] = [];
+  let filled = 0;
+
+  for (const key of keys) {
+    if (counts[key] > 0) {
+      filled++;
+    } else {
+      gaps.push(key);
+    }
+  }
+
+  return {
+    filled,
+    total,
+    gaps,
+  };
+}

--- a/src/lib/metrics/gifts.test.ts
+++ b/src/lib/metrics/gifts.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { giftStats } from './gifts'
+
+describe('gifts', () => {
+  it('counts hits misses and unrated', () => {
+    const input = [
+      { howItLanded: 'hit' },
+      { howItLanded: 'hit' },
+      { howItLanded: 'miss' },
+      { howItLanded: null },
+    ]
+    const stats = giftStats(input)
+
+    expect(stats.logged).toBe(4)
+    expect(stats.hits).toBe(2)
+    expect(stats.misses).toBe(1)
+    expect(stats.unrated).toBe(1)
+    expect(stats.successRate).toBe(2 / 3)
+  })
+
+  it('no rated gifts means null success rate', () => {
+    const input = [{ howItLanded: null }]
+    const stats = giftStats(input)
+
+    expect(stats.unrated).toBe(1)
+    expect(stats.successRate).toBe(null)
+  })
+
+  it('empty list is all zeros', () => {
+    const stats = giftStats([])
+
+    expect(stats.logged).toBe(0)
+    expect(stats.hits).toBe(0)
+    expect(stats.misses).toBe(0)
+    expect(stats.unrated).toBe(0)
+    expect(stats.successRate).toBe(null)
+  })
+})

--- a/src/lib/metrics/gifts.ts
+++ b/src/lib/metrics/gifts.ts
@@ -1,0 +1,35 @@
+export type GiftStats = {
+  logged: number;
+  hits: number;
+  misses: number;
+  unrated: number;
+  successRate: number | null;
+};
+
+export function giftStats(gifts: { howItLanded: string | null }[]): GiftStats {
+  const logged = gifts.length;
+  let hits = 0;
+  let misses = 0;
+  let unrated = 0;
+
+  for (const gift of gifts) {
+    if (gift.howItLanded === 'hit') {
+      hits++;
+    } else if (gift.howItLanded === 'miss') {
+      misses++;
+    } else {
+      unrated++;
+    }
+  }
+
+  const totalRated = hits + misses;
+  const successRate = totalRated > 0 ? hits / totalRated : null;
+
+  return {
+    logged,
+    hits,
+    misses,
+    unrated,
+    successRate,
+  };
+}

--- a/src/lib/metrics/moodBuckets.test.ts
+++ b/src/lib/metrics/moodBuckets.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import { moodBuckets } from './moodBuckets'
+
+describe('moodBuckets', () => {
+  it('groups same-day moods into one bucket', () => {
+    const day1 = new Date(Date.UTC(2026, 7, 17, 10, 0, 0));
+    const day1Late = new Date(Date.UTC(2026, 7, 17, 22, 0, 0));
+    const day2 = new Date(Date.UTC(2026, 7, 18, 5, 0, 0));
+
+    const input = [
+      { label: 'Happy', recordedAt: day1 },
+      { label: 'Calm', recordedAt: day1Late },
+      { label: 'Energetic', recordedAt: day2 },
+    ];
+
+    const result = moodBuckets(input);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].day).toBe('2026-08-17');
+    expect(result[0].labels).toHaveLength(2);
+    expect(result[0].labels).toEqual(['Happy', 'Calm']);
+  })
+
+  it('buckets are sorted by day ascending', () => {
+    const day1 = new Date(Date.UTC(2026, 7, 17, 10, 0, 0));
+    const day2 = new Date(Date.UTC(2026, 7, 18, 10, 0, 0));
+
+    const input = [
+      { label: 'Late', recordedAt: day2 },
+      { label: 'Early', recordedAt: day1 },
+    ];
+
+    const result = moodBuckets(input);
+
+    expect(result[0].day).toBe('2026-08-17');
+  })
+
+  it('empty input is an empty array', () => {
+    expect(moodBuckets([])).toEqual([]);
+  })
+})

--- a/src/lib/metrics/moodBuckets.ts
+++ b/src/lib/metrics/moodBuckets.ts
@@ -1,0 +1,27 @@
+export type MoodBucket = {
+  day: string;
+  labels: string[];
+};
+
+export function moodBuckets(moods: { label: string; recordedAt: Date }[]): MoodBucket[] {
+  if (moods.length === 0) {
+    return [];
+  }
+
+  const bucketsMap: Record<string, string[]> = {};
+
+  for (const mood of moods) {
+    const day = mood.recordedAt.toISOString().slice(0, 10);
+    if (!bucketsMap[day]) {
+      bucketsMap[day] = [];
+    }
+    bucketsMap[day].push(mood.label);
+  }
+
+  return Object.keys(bucketsMap)
+    .sort()
+    .map((day) => ({
+      day,
+      labels: bucketsMap[day],
+    }));
+}

--- a/src/lib/metrics/recency.test.ts
+++ b/src/lib/metrics/recency.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { daysSinceLastTouch } from './recency'
+
+describe('recency', () => {
+  it('days since the latest date', () => {
+    const dates = [
+      new Date(Date.UTC(2026, 7, 10)), // 2026-08-10
+      new Date(Date.UTC(2026, 7, 15)), // 2026-08-15
+    ]
+    const today = new Date(Date.UTC(2026, 7, 18)) // 2026-08-18
+    
+    const result = daysSinceLastTouch(dates, today)
+    expect(result).toBe(3)
+  })
+
+  it('empty history is null', () => {
+    const today = new Date(Date.UTC(2026, 7, 18))
+    const result = daysSinceLastTouch([], today)
+    expect(result).toBeNull()
+  })
+
+  it('a touch today is zero', () => {
+    const dates = [new Date(Date.UTC(2026, 7, 18, 9, 0, 0))]
+    const today = new Date(Date.UTC(2026, 7, 18, 12, 0, 0))
+    
+    const result = daysSinceLastTouch(dates, today)
+    expect(result).toBe(0)
+  })
+})

--- a/src/lib/metrics/recency.ts
+++ b/src/lib/metrics/recency.ts
@@ -1,0 +1,17 @@
+export function daysSinceLastTouch(dates: Date[], today: Date): number | null {
+  if (dates.length === 0) {
+    return null;
+  }
+
+  const latestDate = dates.reduce((latest, current) => {
+    return current > latest ? current : latest;
+  }, dates[0]);
+
+  if (latestDate >= today) {
+    return 0;
+  }
+
+  const msPerDay = 86400000;
+  const diffInMs = today.getTime() - latestDate.getTime();
+  return Math.floor(diffInMs / msPerDay);
+}

--- a/src/lib/portrait/load.test.ts
+++ b/src/lib/portrait/load.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { getPortrait } from './load'
+import { prisma } from '@/lib/db'
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    profile: {
+      findUnique: vi.fn(),
+    },
+  },
+}))
+
+describe('load', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns null for an\nunknown profile', async () => {
+    vi.mocked(prisma.profile.findUnique).mockResolvedValue(null as any)
+
+    const result = await getPortrait('unknown-id')
+
+    expect(result).toBeNull()
+  })
+
+  it('maps text rows to plain strings', async () => {
+    vi.mocked(prisma.profile.findUnique).mockResolvedValue({
+      name: 'Ada',
+      likes: [{ text: 'tea' } as any],
+      dislikes: [],
+      jokes: [],
+      dreams: [{ description: 'a cabin' } as any],
+      moods: [],
+      events: [],
+      gifts: [],
+      trips: [],
+      occasions: [],
+    } as any)
+
+    const result = await getPortrait('ada-id')
+
+    expect(result?.likes).toEqual(['tea'])
+    expect(result?.dreams).toEqual(['a cabin'])
+  })
+
+  it('keeps mood fields for the timeline', async () => {
+    const date = new Date(Date.UTC(2026, 7, 1, 0, 0, 0))
+    vi.mocked(prisma.profile.findUnique).mockResolvedValue({
+      name: 'Ada',
+      likes: [],
+      dislikes: [],
+      jokes: [],
+      dreams: [],
+      moods: [{ label: 'happy', note: null, recordedAt: date } as any],
+      events: [],
+      gifts: [],
+      trips: [],
+      occasions: [],
+    } as any)
+
+    const result = await getPortrait('ada-id')
+
+    expect(result?.moods[0].label).toBe('happy')
+    expect(result?.moods[0].recordedAt.getUTCFullYear()).toBe(2026)
+    expect(result?.moods[0].recordedAt.getUTCMonth()).toBe(7)
+    expect(result?.moods[0].recordedAt.getUTCDate()).toBe(1)
+  })
+
+  it('fetches everything in one query', async () => {
+    vi.mocked(prisma.profile.findUnique).mockResolvedValue(null as any)
+
+    await getPortrait('ada-id')
+
+    expect(prisma.profile.findUnique).toHaveBeenCalledTimes(1)
+    expect(prisma.profile.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'ada-id' },
+        include: expect.objectContaining({
+          moods: { orderBy: { recordedAt: 'asc' } },
+          events: { orderBy: { occurredAt: 'desc' }, take: 20 },
+        }),
+      }),
+    )
+  })
+})

--- a/src/lib/portrait/load.ts
+++ b/src/lib/portrait/load.ts
@@ -1,0 +1,85 @@
+import { prisma } from "@/lib/db";
+
+export type Portrait = {
+  name: string;
+  likes: string[];
+  dislikes: string[];
+  jokes: string[];
+  dreams: string[];
+  moods: {
+    label: string;
+    note: string | null;
+    recordedAt: Date;
+  }[];
+  events: {
+    title: string;
+    note: string | null;
+    occurredAt: Date;
+  }[];
+  gifts: {
+    description: string;
+    givenAt: Date | null;
+    howItLanded: string | null;
+  }[];
+  trips: string[];
+  occasions: {
+    label: string;
+    month: number;
+    day: number;
+  }[];
+};
+
+export async function getPortrait(profileId: string): Promise<Portrait | null> {
+  const profile = await prisma.profile.findUnique({
+    where: { id: profileId },
+    include: {
+      likes: true,
+      dislikes: true,
+      jokes: true,
+      dreams: true,
+      gifts: true,
+      trips: true,
+      occasions: true,
+      moods: {
+        orderBy: { recordedAt: "asc" }
+      },
+      events: {
+        orderBy: { occurredAt: "desc" },
+        take: 20
+      }
+    }
+  });
+
+  if (!profile) {
+    return null;
+  }
+
+  return {
+    name: profile.name,
+    likes: profile.likes.map((l) => l.text),
+    dislikes: profile.dislikes.map((d) => d.text),
+    jokes: profile.jokes.map((j) => j.text),
+    dreams: profile.dreams.map((dr) => dr.description),
+    moods: profile.moods.map((m) => ({
+      label: m.label,
+      note: m.note,
+      recordedAt: m.recordedAt
+    })),
+    events: profile.events.map((e) => ({
+      title: e.title,
+      note: e.note,
+      occurredAt: e.occurredAt
+    })),
+    gifts: profile.gifts.map((g) => ({
+      description: g.description,
+      givenAt: g.givenAt,
+      howItLanded: g.howItLanded
+    })),
+    trips: profile.trips.map((t) => t.destination),
+    occasions: profile.occasions.map((o) => ({
+      label: o.label,
+      month: o.month,
+      day: o.day
+    }))
+  };
+}


### PR DESCRIPTION
Fourth hand-off: two identical failed-red dispatches — the model couldn't produce a parsing test file for this shape (async server component, two mocks, typed fixture). Identical-signature failure twice is the wall; #80's flaky red landed on retry, this didn't.

Red-green: missing-unit red first. Metrics and `PortraitView` deliberately unmocked — the test proves real wiring, including the coverage arithmetic through real modules.

**Gates:** 115 tests ✅ · tsc ✅ · lint ✅

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgUuHL6M6pBwuwozBPFph3