### PR TITLE
fix: bundle the rhel Query Engine for Vercel's runtime

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -5,7 +5,11 @@
 // Try Prisma Accelerate: https://pris.ly/cli/accelerate-init
 
 generator client {
-  provider = "prisma-client-js"
+  provider      = "prisma-client-js"
+  // "native" for local dev (darwin) and Docker; rhel for Vercel's Lambda
+  // runtime — without it production throws PrismaClientInitializationError:
+  // "could not locate the Query Engine for runtime rhel-openssl-3.0.x".
+  binaryTargets = ["native", "rhel-openssl-3.0.x"]
 }
 
 datasource db {


### PR DESCRIPTION
Production `/portrait` 500s with `PrismaClientInitializationError: could not locate the Query Engine for runtime rhel-openssl-3.0.x` — the generated client only carried the build platform's engine. `binaryTargets = ["native", "rhel-openssl-3.0.x"]` ships both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgUuHL6M6pBwuwozBPFph3