### PR TITLE
feat(#108): Story 1 — Ensure a linked profile

### DIFF
--- a/src/lib/onboarding/link.test.ts
+++ b/src/lib/onboarding/link.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ensureLinkedProfile } from './link'
+import { prisma as db } from '@/lib/db'
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    telegramChat: {
+      findUnique: vi.fn(),
+      create: vi.fn(),
+    },
+    profile: {
+      findFirst: vi.fn(),
+      create: vi.fn(),
+    },
+  },
+}))
+
+describe('link', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns the existing link without writing', async () => {
+    vi.mocked(db.telegramChat.findUnique).mockResolvedValue({
+      id: 'chat-123',
+      chatId: '42',
+      profileId: 'p1',
+      createdAt: new Date(Date.UTC(2024, 0, 1)),
+    } as any)
+
+    const result = await ensureLinkedProfile('42')
+
+    expect(result).toEqual({ profileId: 'p1', created: false })
+    expect(db.telegramChat.create).not.toHaveBeenCalled()
+  })
+
+  it('links an existing profile', async () => {
+    vi.mocked(db.telegramChat.findUnique).mockResolvedValue(null as any)
+    vi.mocked(db.profile.findFirst).mockResolvedValue({
+      id: 'p1',
+      name: 'Existing',
+    } as any)
+    vi.mocked(db.telegramChat.create).mockResolvedValue({ id: 'chat-42' } as any)
+
+    const result = await ensureLinkedProfile('42')
+
+    expect(db.telegramChat.create).toHaveBeenCalledWith({
+      data: { chatId: '42', profileId: 'p1' },
+    })
+    expect(result.created).toBe(true)
+    expect(result.profileId).toBe('p1')
+  })
+
+  it('creates the profile when none exists', async () => {
+    vi.mocked(db.telegramChat.findUnique).mockResolvedValue(null as any)
+    vi.mocked(db.profile.findFirst).mockResolvedValue(null as any)
+    vi.mocked(db.profile.create).mockResolvedValue({
+      id: 'p2',
+      name: 'Your person',
+    } as any)
+    vi.mocked(db.telegramChat.create).mockResolvedValue({ id: 'chat-42' } as any)
+
+    const result = await ensureLinkedProfile('42')
+
+    expect(db.profile.create).toHaveBeenCalledWith({
+      data: { name: 'Your person' },
+    })
+    expect(result.profileId).toBe('p2')
+    expect(result.created).toBe(true)
+  })
+})

--- a/src/lib/onboarding/link.ts
+++ b/src/lib/onboarding/link.ts
@@ -1,0 +1,28 @@
+import { prisma } from '@/lib/db';
+
+export async function ensureLinkedProfile(chatId: string): Promise<{ profileId: string; created: boolean }> {
+  const existingChat = await prisma.telegramChat.findUnique({
+    where: { chatId },
+  });
+
+  if (existingChat) {
+    return { profileId: existingChat.profileId, created: false };
+  }
+
+  let profile = await prisma.profile.findFirst();
+
+  if (!profile) {
+    profile = await prisma.profile.create({
+      data: { name: 'Your person' },
+    });
+  }
+
+  await prisma.telegramChat.create({
+    data: {
+      chatId,
+      profileId: profile.id,
+    },
+  });
+
+  return { profileId: profile.id, created: true };
+}


### PR DESCRIPTION
## Summary

Implements story #108: Story 1 — Ensure a linked profile

## Verified gates (auto-captured by dag-poc)

- `build` exit 0
- `smoke` exit 0
- `smoke` exit 0

## Implementation provenance

- Model: `spike-coder-v3:latest` (local Ollama)
- LLM calls: 3
- Prompt tokens: 20806
- Output tokens: 2091

Closes #108

Co-Authored-By: gemma4:26b (Spike coder) <noreply@spike.local>

## Verified gates *(auto-captured by spike-guard)*

- build: ✓ exit 0 (run at 2026-08-19T20:54:00Z)
- lint: ✓ exit 0 (run at 2026-08-19T20:53:54Z)
- test: ✓ exit 0 (run at 2026-08-19T20:53:55Z)
