### PR TITLE
feat(#109): Story 2 — Onboarding step (hand-written)

### DIFF
--- a/src/lib/onboarding/link.test.ts
+++ b/src/lib/onboarding/link.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ensureLinkedProfile } from './link'
+import { prisma as db } from '@/lib/db'
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    telegramChat: {
+      findUnique: vi.fn(),
+      create: vi.fn(),
+    },
+    profile: {
+      findFirst: vi.fn(),
+      create: vi.fn(),
+    },
+  },
+}))
+
+describe('link', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns the existing link without writing', async () => {
+    vi.mocked(db.telegramChat.findUnique).mockResolvedValue({
+      id: 'chat-123',
+      chatId: '42',
+      profileId: 'p1',
+      createdAt: new Date(Date.UTC(2024, 0, 1)),
+    } as any)
+
+    const result = await ensureLinkedProfile('42')
+
+    expect(result).toEqual({ profileId: 'p1', created: false })
+    expect(db.telegramChat.create).not.toHaveBeenCalled()
+  })
+
+  it('links an existing profile', async () => {
+    vi.mocked(db.telegramChat.findUnique).mockResolvedValue(null as any)
+    vi.mocked(db.profile.findFirst).mockResolvedValue({
+      id: 'p1',
+      name: 'Existing',
+    } as any)
+    vi.mocked(db.telegramChat.create).mockResolvedValue({ id: 'chat-42' } as any)
+
+    const result = await ensureLinkedProfile('42')
+
+    expect(db.telegramChat.create).toHaveBeenCalledWith({
+      data: { chatId: '42', profileId: 'p1' },
+    })
+    expect(result.created).toBe(true)
+    expect(result.profileId).toBe('p1')
+  })
+
+  it('creates the profile when none exists', async () => {
+    vi.mocked(db.telegramChat.findUnique).mockResolvedValue(null as any)
+    vi.mocked(db.profile.findFirst).mockResolvedValue(null as any)
+    vi.mocked(db.profile.create).mockResolvedValue({
+      id: 'p2',
+      name: 'Your person',
+    } as any)
+    vi.mocked(db.telegramChat.create).mockResolvedValue({ id: 'chat-42' } as any)
+
+    const result = await ensureLinkedProfile('42')
+
+    expect(db.profile.create).toHaveBeenCalledWith({
+      data: { name: 'Your person' },
+    })
+    expect(result.profileId).toBe('p2')
+    expect(result.created).toBe(true)
+  })
+})

--- a/src/lib/onboarding/link.ts
+++ b/src/lib/onboarding/link.ts
@@ -1,0 +1,28 @@
+import { prisma } from '@/lib/db';
+
+export async function ensureLinkedProfile(chatId: string): Promise<{ profileId: string; created: boolean }> {
+  const existingChat = await prisma.telegramChat.findUnique({
+    where: { chatId },
+  });
+
+  if (existingChat) {
+    return { profileId: existingChat.profileId, created: false };
+  }
+
+  let profile = await prisma.profile.findFirst();
+
+  if (!profile) {
+    profile = await prisma.profile.create({
+      data: { name: 'Your person' },
+    });
+  }
+
+  await prisma.telegramChat.create({
+    data: {
+      chatId,
+      profileId: profile.id,
+    },
+  });
+
+  return { profileId: profile.id, created: true };
+}

--- a/src/lib/onboarding/step.test.ts
+++ b/src/lib/onboarding/step.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { prisma } from '@/lib/db'
+import { QUESTIONS } from '@/lib/questionnaire/questions'
+import { onboardingStep } from './step'
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    profile: { findUnique: vi.fn(), update: vi.fn() },
+    questionnaireAnswer: { findMany: vi.fn(), create: vi.fn() },
+    likesEntry: { create: vi.fn() },
+    dislikesEntry: { create: vi.fn() },
+    joke: { create: vi.fn() },
+    mood: { create: vi.fn() },
+    dream: { create: vi.fn() },
+    event: { create: vi.fn() },
+    gift: { create: vi.fn() },
+    trip: { create: vi.fn() },
+  },
+}))
+// questions/flow are pure local modules — never mocked.
+
+const CREATES = () => [
+  prisma.questionnaireAnswer.create, prisma.likesEntry.create,
+  prisma.dislikesEntry.create, prisma.joke.create, prisma.mood.create,
+  prisma.dream.create, prisma.event.create, prisma.gift.create,
+  prisma.trip.create,
+]
+
+describe('onboardingStep', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(prisma.profile.update).mockResolvedValue({} as never)
+    vi.mocked(prisma.questionnaireAnswer.findMany).mockResolvedValue([] as never)
+    vi.mocked(prisma.questionnaireAnswer.create).mockResolvedValue({} as never)
+    vi.mocked(prisma.likesEntry.create).mockResolvedValue({} as never)
+  })
+
+  it('asks for the name first', async () => {
+    vi.mocked(prisma.profile.findUnique).mockResolvedValue(
+      { id: 'p1', name: 'Your person' } as never)
+
+    const reply = await onboardingStep('p1', '')
+
+    expect(reply).toContain('name')
+    for (const fn of CREATES()) expect(fn).not.toHaveBeenCalled()
+  })
+
+  it('stores the name and asks the first question', async () => {
+    vi.mocked(prisma.profile.findUnique).mockResolvedValue(
+      { id: 'p1', name: 'Your person' } as never)
+
+    const reply = await onboardingStep('p1', 'Ada')
+
+    expect(prisma.profile.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ name: 'Ada' }) }))
+    expect(reply).toContain(QUESTIONS[0].prompt)
+  })
+
+  it('stores an answer to its field and asks the next question', async () => {
+    vi.mocked(prisma.profile.findUnique).mockResolvedValue(
+      { id: 'p1', name: 'Ada' } as never)
+
+    const reply = await onboardingStep('p1', 'tea and rainy mornings')
+
+    expect(prisma.questionnaireAnswer.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ questionId: QUESTIONS[0].id }),
+      }))
+    // QUESTIONS[0].field is 'likes'
+    expect(prisma.likesEntry.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: { profileId: 'p1', text: 'tea and rainy mornings' },
+      }))
+    expect(reply).toBe(QUESTIONS[1].prompt)
+  })
+
+  it('hands over to the coach when complete', async () => {
+    vi.mocked(prisma.profile.findUnique).mockResolvedValue(
+      { id: 'p1', name: 'Ada' } as never)
+    vi.mocked(prisma.questionnaireAnswer.findMany).mockResolvedValue(
+      QUESTIONS.map((q) => ({ questionId: q.id })) as never)
+
+    const reply = await onboardingStep('p1', 'anything')
+
+    expect(reply).toBeNull()
+    for (const fn of CREATES()) expect(fn).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/onboarding/step.ts
+++ b/src/lib/onboarding/step.ts
@@ -1,0 +1,86 @@
+import { prisma } from '@/lib/db'
+import { QUESTIONS, type Question } from '@/lib/questionnaire/questions'
+import { nextQuestion } from '@/lib/questionnaire/flow'
+
+const PLACEHOLDER_NAME = 'Your person'
+
+async function storeAnswer(
+  profileId: string,
+  question: Question,
+  text: string
+): Promise<void> {
+  await prisma.questionnaireAnswer.create({
+    data: { profileId, questionId: question.id, answer: text },
+  })
+  switch (question.field) {
+    case 'likes':
+      await prisma.likesEntry.create({ data: { profileId, text } })
+      break
+    case 'dislikes':
+      await prisma.dislikesEntry.create({ data: { profileId, text } })
+      break
+    case 'jokes':
+      await prisma.joke.create({ data: { profileId, text } })
+      break
+    case 'moods':
+      await prisma.mood.create({ data: { profileId, label: text } })
+      break
+    case 'dreams':
+      await prisma.dream.create({ data: { profileId, description: text } })
+      break
+    case 'events':
+      await prisma.event.create({
+        data: { profileId, title: text, occurredAt: new Date() },
+      })
+      break
+    case 'gifts':
+      await prisma.gift.create({ data: { profileId, description: text } })
+      break
+    case 'trips':
+      await prisma.trip.create({ data: { profileId, destination: text } })
+      break
+  }
+}
+
+/** The next message the bot should send, or null when onboarding is done. */
+export async function onboardingStep(
+  profileId: string,
+  text: string
+): Promise<string | null> {
+  const trimmed = text.trim()
+
+  const profile = await prisma.profile.findUnique({ where: { id: profileId } })
+  if (profile && profile.name === PLACEHOLDER_NAME) {
+    if (!trimmed) {
+      return 'Welcome to cherish.ai. What is their name?'
+    }
+    await prisma.profile.update({
+      where: { id: profileId },
+      data: { name: trimmed },
+    })
+    return (
+      `${trimmed} it is. Twelve quick questions to start the portrait.\n\n` +
+      QUESTIONS[0].prompt
+    )
+  }
+
+  const answered = await prisma.questionnaireAnswer.findMany({
+    where: { profileId },
+  })
+  const answeredIds = answered.map((a) => a.questionId)
+  const current = nextQuestion(answeredIds)
+  if (current === null) {
+    return null // questionnaire complete: the coach takes it from here
+  }
+
+  await storeAnswer(profileId, current, trimmed)
+  const upNext = nextQuestion([...answeredIds, current.id])
+  if (upNext === null) {
+    return (
+      'That completes the questionnaire — the portrait has its first ' +
+      'layer. From here, just talk to me: tell me how things are going, ' +
+      'and ask whenever you need an idea.'
+    )
+  }
+  return upNext.prompt
+}


### PR DESCRIPTION
Three-strikes hand-off (three distinct failure signatures). Largest logic unit in the epic: name capture, twelve-question walk, eight field-specific writes. Red-green; questions/flow run real, only the db mocked.

**Gates:** 123 tests ✅ · tsc ✅ · lint ✅

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgUuHL6M6pBwuwozBPFph3