### PR TITLE
Epics 4 + 5 — onboarding, conversation memory, portrait CRUD

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -43,6 +43,7 @@ model LikesEntry {
   profileId String
   text      String
   createdAt DateTime @default(now())
+  source    String   @default("manual")
   profile   Profile  @relation(fields: [profileId], references: [id], onDelete: Cascade)
 }
 
@@ -51,6 +52,7 @@ model DislikesEntry {
   profileId String
   text      String
   createdAt DateTime @default(now())
+  source    String   @default("manual")
   profile   Profile  @relation(fields: [profileId], references: [id], onDelete: Cascade)
 }
 
@@ -59,6 +61,7 @@ model Joke {
   profileId String
   text      String
   createdAt DateTime @default(now())
+  source    String   @default("manual")
   profile   Profile  @relation(fields: [profileId], references: [id], onDelete: Cascade)
 }
 
@@ -68,6 +71,7 @@ model Mood {
   label      String
   note       String?
   recordedAt DateTime @default(now())
+  source    String   @default("manual")
   profile    Profile  @relation(fields: [profileId], references: [id], onDelete: Cascade)
 }
 
@@ -78,6 +82,7 @@ model Event {
   occurredAt DateTime
   note       String?
   createdAt  DateTime @default(now())
+  source    String   @default("manual")
   profile    Profile  @relation(fields: [profileId], references: [id], onDelete: Cascade)
 }
 
@@ -88,6 +93,7 @@ model Gift {
   givenAt     DateTime?
   howItLanded String?
   createdAt   DateTime  @default(now())
+  source    String   @default("manual")
   profile     Profile   @relation(fields: [profileId], references: [id], onDelete: Cascade)
 }
 
@@ -99,6 +105,7 @@ model Trip {
   endDate     DateTime?
   note        String?
   createdAt   DateTime  @default(now())
+  source    String   @default("manual")
   profile     Profile   @relation(fields: [profileId], references: [id], onDelete: Cascade)
 }
 
@@ -107,6 +114,7 @@ model Dream {
   profileId   String
   description String
   createdAt   DateTime @default(now())
+  source    String   @default("manual")
   profile     Profile  @relation(fields: [profileId], references: [id], onDelete: Cascade)
 }
 

--- a/src/app/actions/editEntry.test.ts
+++ b/src/app/actions/editEntry.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { prisma } from '@/lib/db'
+import { revalidatePath } from 'next/cache'
+import { updateEntry, deleteEntry } from './editEntry'
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    likesEntry: { update: vi.fn(), delete: vi.fn() },
+    dislikesEntry: { update: vi.fn(), delete: vi.fn() },
+    joke: { update: vi.fn(), delete: vi.fn() },
+    dream: { update: vi.fn(), delete: vi.fn() },
+    trip: { update: vi.fn(), delete: vi.fn() },
+  },
+}))
+vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }))
+
+const MODELS = () => [
+  prisma.likesEntry, prisma.dislikesEntry, prisma.joke, prisma.dream, prisma.trip,
+]
+
+describe('editEntry', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    for (const m of MODELS()) {
+      vi.mocked(m.update).mockResolvedValue({} as never)
+      vi.mocked(m.delete).mockResolvedValue({} as never)
+    }
+  })
+
+  it("updates a dream's description", async () => {
+    const result = await updateEntry('dreams', 'd1', 'a bigger cabin')
+
+    expect(result).toEqual({ ok: true })
+    expect(prisma.dream.update).toHaveBeenCalledWith({
+      where: { id: 'd1' },
+      data: { description: 'a bigger cabin' },
+    })
+    expect(revalidatePath).toHaveBeenCalledWith('/portrait')
+  })
+
+  it('deletes a like', async () => {
+    const result = await deleteEntry('likes', 'l1')
+
+    expect(result).toEqual({ ok: true })
+    expect(prisma.likesEntry.delete).toHaveBeenCalledWith({ where: { id: 'l1' } })
+  })
+
+  it('unknown field is rejected without a db call', async () => {
+    expect(await updateEntry('moods' as never, 'x', 'y')).toEqual({ ok: false })
+    expect(await deleteEntry('moods' as never, 'x')).toEqual({ ok: false })
+    for (const m of MODELS()) {
+      expect(m.update).not.toHaveBeenCalled()
+      expect(m.delete).not.toHaveBeenCalled()
+    }
+  })
+
+  it('a failed delete reports not-ok', async () => {
+    vi.mocked(prisma.joke.delete).mockRejectedValue(new Error('gone'))
+
+    expect(await deleteEntry('jokes', 'j1')).toEqual({ ok: false })
+  })
+})

--- a/src/app/actions/editEntry.ts
+++ b/src/app/actions/editEntry.ts
@@ -1,0 +1,58 @@
+'use server'
+
+import { prisma } from '@/lib/db'
+import { revalidatePath } from 'next/cache'
+
+export type EditableField = 'likes' | 'dislikes' | 'jokes' | 'dreams' | 'trips'
+
+// Each model's own text column — they are not interchangeable.
+const TABLE = {
+  likes: (id: string, text: string) =>
+    prisma.likesEntry.update({ where: { id }, data: { text } }),
+  dislikes: (id: string, text: string) =>
+    prisma.dislikesEntry.update({ where: { id }, data: { text } }),
+  jokes: (id: string, text: string) =>
+    prisma.joke.update({ where: { id }, data: { text } }),
+  dreams: (id: string, text: string) =>
+    prisma.dream.update({ where: { id }, data: { description: text } }),
+  trips: (id: string, text: string) =>
+    prisma.trip.update({ where: { id }, data: { destination: text } }),
+} as const
+
+const DELETE = {
+  likes: (id: string) => prisma.likesEntry.delete({ where: { id } }),
+  dislikes: (id: string) => prisma.dislikesEntry.delete({ where: { id } }),
+  jokes: (id: string) => prisma.joke.delete({ where: { id } }),
+  dreams: (id: string) => prisma.dream.delete({ where: { id } }),
+  trips: (id: string) => prisma.trip.delete({ where: { id } }),
+} as const
+
+function known(field: string): field is EditableField {
+  return field in TABLE
+}
+
+export async function updateEntry(
+  field: EditableField,
+  id: string,
+  text: string
+): Promise<{ ok: boolean }> {
+  const trimmed = text.trim()
+  if (!known(field) || !trimmed) return { ok: false }
+  await TABLE[field](id, trimmed)
+  revalidatePath('/portrait')
+  return { ok: true }
+}
+
+export async function deleteEntry(
+  field: EditableField,
+  id: string
+): Promise<{ ok: boolean }> {
+  if (!known(field)) return { ok: false }
+  try {
+    await DELETE[field](id)
+  } catch {
+    return { ok: false }
+  }
+  revalidatePath('/portrait')
+  return { ok: true }
+}

--- a/src/app/actions/rateGift.test.ts
+++ b/src/app/actions/rateGift.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { prisma } from '@/lib/db'
+import { revalidatePath } from 'next/cache'
+import { rateGift } from './rateGift'
+
+vi.mock('@/lib/db', () => ({ prisma: { gift: { update: vi.fn() } } }))
+vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }))
+
+describe('rateGift', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(prisma.gift.update).mockResolvedValue({} as never)
+  })
+
+  it('rates a gift as landed', async () => {
+    const result = await rateGift('g1', 'hit')
+
+    expect(result).toEqual({ ok: true })
+    expect(prisma.gift.update).toHaveBeenCalledWith({
+      where: { id: 'g1' },
+      data: { howItLanded: 'hit' },
+    })
+    expect(revalidatePath).toHaveBeenCalledWith('/portrait')
+  })
+
+  it('rejects an unknown outcome', async () => {
+    expect(await rateGift('g1', 'meh' as never)).toEqual({ ok: false })
+    expect(prisma.gift.update).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/actions/rateGift.ts
+++ b/src/app/actions/rateGift.ts
@@ -1,0 +1,14 @@
+'use server'
+
+import { prisma } from '@/lib/db'
+import { revalidatePath } from 'next/cache'
+
+export async function rateGift(
+  id: string,
+  outcome: 'hit' | 'miss'
+): Promise<{ ok: boolean }> {
+  if (outcome !== 'hit' && outcome !== 'miss') return { ok: false }
+  await prisma.gift.update({ where: { id }, data: { howItLanded: outcome } })
+  revalidatePath('/portrait')
+  return { ok: true }
+}

--- a/src/components/EditableChip.test.tsx
+++ b/src/components/EditableChip.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import EditableChip from './EditableChip'
+
+vi.mock('@/app/actions/editEntry', () => ({ updateEntry: vi.fn(), deleteEntry: vi.fn() }))
+
+describe('EditableChip', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('edits in place on enter', async () => {
+    const user = userEvent.setup()
+    const { updateEntry } = await import('@/app/actions/editEntry')
+    vi.mocked(updateEntry).mockResolvedValue({ ok: true })
+
+    render(<EditableChip field="likes" id="l1" text="tea" source="manual" />)
+
+    const editButton = screen.getByRole('button', { name: 'Edit tea' })
+    await user.click(editButton)
+
+    const input = screen.getByRole('textbox')
+    await user.clear(input)
+    await user.type(input, 'green tea')
+    await user.keyboard('{Enter}')
+
+    expect(updateEntry).toHaveBeenCalledWith('likes', 'l1', 'green tea')
+    expect(screen.getByText('tea')).toBeInTheDocument()
+  })
+
+  it('deletes on the delete button', async () => {
+    const user = userEvent.setup()
+    const { deleteEntry } = await import('@/app/actions/editEntry')
+    vi.mocked(deleteEntry).mockResolvedValue({ ok: true })
+
+    render(<EditableChip field="likes" id="l1" text="tea" source="manual" />)
+
+    const deleteButton = screen.getByRole('button', { name: 'Delete tea' })
+    await user.click(deleteButton)
+
+    expect(deleteEntry).toHaveBeenCalledWith('likes', 'l1')
+  })
+
+  it('escape cancels without saving', async () => {
+    const user = userEvent.setup()
+    const { updateEntry } = await import('@/app/actions/editEntry')
+    vi.mocked(updateEntry).mockResolvedValue({ ok: true })
+
+    render(<EditableChip field="likes" id="l1" text="tea" source="manual" />)
+
+    const editButton = screen.getByRole('button', { name: 'Edit tea' })
+    await user.click(editButton)
+
+    await user.keyboard('{Escape}')
+
+    expect(updateEntry).not.toHaveBeenCalled()
+    expect(screen.getByText('tea')).toBeInTheDocument()
+  })
+
+  it('extracted chips carry the ai marker', async () => {
+    const { rerender } = render(<EditableChip field="likes" id="l1" text="tea" source="extracted" />)
+    expect(screen.getByTestId('source-marker')).toHaveTextContent('ai')
+
+    rerender(<EditableChip field="likes" id="l1" text="tea" source="manual" />)
+    expect(screen.queryByTestId('source-marker')).toBeNull()
+  })
+})

--- a/src/components/EditableChip.tsx
+++ b/src/components/EditableChip.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { useState, KeyboardEvent } from 'react';
+import { updateEntry, deleteEntry, type EditableField } from '@/app/actions/editEntry';
+
+interface EditableChipProps {
+  field: EditableField;
+  id: string;
+  text: string;
+  source: string;
+}
+
+export default function EditableChip({ field, id, text, source }: EditableChipProps) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [val, setVal] = useState(text);
+
+  const handleSave = async () => {
+    await updateEntry(field, id, val);
+    setIsEditing(false);
+  };
+
+  const handleKeyDown = async (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      await handleSave();
+    } else if (e.key === 'Escape') {
+      setVal(text);
+      setIsEditing(false);
+    }
+  };
+
+  return (
+    <div className="inline-flex items-center gap-2 rounded-full bg-gray-100 px-3 py-1 text-sm">
+      {isEditing ? (
+        <input
+          value={val}
+          onChange={(e) => setVal(e.target.value)}
+          onKeyDown={handleKeyDown}
+          className="w-auto bg-transparent px-1 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+          autoFocus
+        />
+      ) : (
+        <button
+          onClick={() => setIsEditing(true)}
+          aria-label={`Edit ${text}`}
+          className="font-medium text-gray-900"
+        >
+          {text}
+        </button>
+      )}
+      <button
+        onClick={() => deleteEntry(field, id)}
+        aria-label={`Delete ${text}`}
+        className="text-gray-400 hover:text-red-500"
+      >
+        &times;
+      </button>
+      {source === 'extracted' && (
+        <span
+          data-testid="source-marker"
+          className="text-[10px] font-bold uppercase text-emerald-600"
+        >
+          ai
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/components/EditableSection.test.tsx
+++ b/src/components/EditableSection.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import EditableSection from './EditableSection'
+
+// Mocking the action module as required by the AC
+vi.mock('@/app/actions/editEntry', () => ({
+  // We don't need to implement the actual logic, just ensure the module exists
+  // so that EditableChip can import the type/logic without crashing.
+}))
+
+describe('EditableSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders a chip per row', async () => {
+    const rows = [
+      { id: '1', text: 'First entry', source: 'Web' },
+      { id: '2', text: 'Second entry', source: 'App' },
+    ]
+    
+    render(
+      <EditableSection 
+        title="Test Section" 
+        field={'likes' as any} 
+        rows={rows as any} 
+      />
+    )
+
+    const listItems = screen.getAllByRole('listitem')
+    expect(listItems).toHaveLength(2)
+    
+    expect(screen.getByText('First entry')).toBeVisible()
+    expect(screen.getByText('Second entry')).toBeVisible()
+  })
+
+  it('empty rows show the placeholder', async () => {
+    render(
+      <EditableSection 
+        title="Empty Section" 
+        field={'likes' as any} 
+        rows={[]} 
+      />
+    )
+
+    expect(screen.getByText('Nothing here yet.')).toBeInTheDocument()
+    expect(screen.queryByRole('list')).toBeNull()
+  })
+})

--- a/src/components/EditableSection.tsx
+++ b/src/components/EditableSection.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import EditableChip from '@/components/EditableChip';
+import type { EditableField } from '@/app/actions/editEntry';
+import type { EntryRow } from '@/lib/portrait/load';
+
+interface EditableSectionProps {
+  title: string;
+  field: EditableField;
+  rows: EntryRow[];
+}
+
+export default function EditableSection({ title, field, rows }: EditableSectionProps) {
+  return (
+    <section data-testid="portrait-section" className="space-y-4">
+      <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
+        {title}
+      </h2>
+      {rows.length === 0 ? (
+        <p className="text-sm text-zinc-500 dark:text-zinc-400">
+          Nothing here yet.
+        </p>
+      ) : (
+        <ul className="space-y-2">
+          {rows.map((row) => (
+            <li key={row.id}>
+              <EditableChip
+                field={field}
+                id={row.id}
+                text={row.text}
+                source={row.source}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/src/components/GiftHistory.test.tsx
+++ b/src/components/GiftHistory.test.tsx
@@ -1,4 +1,8 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import userEvent from '@testing-library/user-event'
+import { rateGift } from '@/app/actions/rateGift'
+
+vi.mock('@/app/actions/rateGift', () => ({ rateGift: vi.fn() }))
 import { render, screen } from '@testing-library/react'
 import GiftHistory from './GiftHistory'
 
@@ -25,5 +29,23 @@ describe('GiftHistory', () => {
 
     expect(screen.getByText('No gifts logged yet.')).toBeInTheDocument()
     expect(screen.queryByRole('list')).toBeNull()
+  })
+
+  it('unrated gifts offer rating', async () => {
+    vi.mocked(rateGift).mockResolvedValue({ ok: true })
+    render(
+      <GiftHistory
+        gifts={[]}
+        rows={[
+          { id: 'g1', description: 'socks', givenAt: null, howItLanded: null, source: 'manual' },
+          { id: 'g2', description: 'a record player', givenAt: null, howItLanded: 'hit', source: 'manual' },
+        ]}
+      />
+    )
+
+    await userEvent.click(screen.getByRole('button', { name: 'Mark socks landed' }))
+
+    expect(rateGift).toHaveBeenCalledWith('g1', 'hit')
+    expect(screen.queryByRole('button', { name: 'Mark a record player landed' })).toBeNull()
   })
 })

--- a/src/components/GiftHistory.tsx
+++ b/src/components/GiftHistory.tsx
@@ -1,3 +1,8 @@
+'use client'
+
+import { rateGift } from '@/app/actions/rateGift'
+import type { GiftRow } from '@/lib/portrait/load'
+
 type Gift = {
   description: string
   givenAt: Date | null
@@ -16,20 +21,56 @@ const BADGE: Record<string, string> = {
   unrated: 'border-line bg-paper text-ink-soft',
 }
 
-export default function GiftHistory({ gifts }: { gifts: Gift[] }) {
-  if (gifts.length === 0) {
+function Badge({ howItLanded }: { howItLanded: string | null }) {
+  return (
+    <span
+      data-testid="gift-outcome"
+      className={`shrink-0 rounded-full border px-2.5 py-0.5 text-xs font-medium ${BADGE[outcome(howItLanded)]}`}
+    >
+      {outcome(howItLanded)}
+    </span>
+  )
+}
+
+export default function GiftHistory({
+  gifts,
+  rows,
+}: {
+  gifts: Gift[]
+  rows?: GiftRow[]
+}) {
+  const list = rows ?? gifts
+  if (list.length === 0) {
     return <p className="text-sm italic text-ink-soft">No gifts logged yet.</p>
   }
   return (
     <ul className="divide-y divide-line">
-      {gifts.map((gift, i) => (
-        <li key={i} className="flex items-center justify-between gap-3 py-3 first:pt-0 last:pb-0">
+      {list.map((gift, i) => (
+        <li
+          key={rows ? (gift as GiftRow).id : i}
+          className="flex items-center justify-between gap-3 py-3 first:pt-0 last:pb-0"
+        >
           <span className="text-sm text-ink">{gift.description}</span>
-          <span
-            data-testid="gift-outcome"
-            className={`shrink-0 rounded-full border px-2.5 py-0.5 text-xs font-medium ${BADGE[outcome(gift.howItLanded)]}`}
-          >
-            {outcome(gift.howItLanded)}
+          <span className="flex shrink-0 items-center gap-1.5">
+            <Badge howItLanded={gift.howItLanded} />
+            {rows && gift.howItLanded === null && (
+              <>
+                <button
+                  aria-label={`Mark ${gift.description} landed`}
+                  onClick={() => rateGift((gift as GiftRow).id, 'hit')}
+                  className="rounded-full border border-good/30 px-2 py-0.5 text-xs text-good hover:bg-good/10"
+                >
+                  landed
+                </button>
+                <button
+                  aria-label={`Mark ${gift.description} missed`}
+                  onClick={() => rateGift((gift as GiftRow).id, 'miss')}
+                  className="rounded-full border border-bad/30 px-2 py-0.5 text-xs text-bad hover:bg-bad/10"
+                >
+                  missed
+                </button>
+              </>
+            )}
           </span>
         </li>
       ))}

--- a/src/components/PortraitView.test.tsx
+++ b/src/components/PortraitView.test.tsx
@@ -7,6 +7,9 @@ import type { Coverage } from '@/lib/metrics/coverage'
 import type { GiftStats } from '@/lib/metrics/gifts'
 import type { MoodBucket } from '@/lib/metrics/moodBuckets'
 
+vi.mock('@/app/actions/editEntry', () => ({ editEntry: vi.fn() }))
+vi.mock('@/app/actions/rateGift', () => ({ rateGift: vi.fn() }))
+
 describe('PortraitView', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -15,7 +18,7 @@ describe('PortraitView', () => {
   it('renders the name and all sections', async () => {
     const portrait: Portrait = {
       name: 'Ada',
-      likes: ['tea'],
+      likes: [],
       dislikes: [],
       jokes: [],
       dreams: [],
@@ -48,6 +51,14 @@ describe('PortraitView', () => {
     const portrait: Portrait = {
       name: 'Ada',
       likes: ['tea'],
+      entries: {
+        likes: [{ id: 'l1', text: 'tea', source: 'manual' }],
+        dislikes: [],
+        jokes: [],
+        dreams: [],
+        trips: [],
+        gifts: [],
+      },
       dislikes: [],
       jokes: [],
       dreams: [],
@@ -105,5 +116,37 @@ describe('PortraitView', () => {
 
     expect(screen.getByRole('button', { name: 'Add mood' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Add entry' })).toBeInTheDocument()
+  })
+
+  it('an entries-less portrait still renders', async () => {
+    const portrait: Portrait = {
+      name: 'Ada',
+      likes: [],
+      dislikes: [],
+      jokes: [],
+      dreams: [],
+      trips: [],
+      gifts: [],
+      moods: [],
+      events: [],
+      occasions: []
+    }
+    const coverage: Coverage = { filled: 1, total: 5, gaps: [] }
+    const giftStats: GiftStats = { logged: 0, hits: 0, misses: 0, unrated: 0, successRate: null }
+    const buckets: MoodBucket[] = []
+
+    render(
+      <PortraitView
+        portrait={portrait}
+        profileId="p1"
+        coverage={coverage}
+        daysSinceTouch={null}
+        giftStats={giftStats}
+        buckets={buckets}
+      />
+    )
+
+    expect(screen.getAllByTestId('portrait-section')).toHaveLength(5)
+    expect(screen.getAllByText('Nothing here yet.')).toHaveLength(5)
   })
 })

--- a/src/components/PortraitView.tsx
+++ b/src/components/PortraitView.tsx
@@ -2,7 +2,7 @@ import type { Portrait } from '@/lib/portrait/load';
 import type { Coverage } from '@/lib/metrics/coverage';
 import type { GiftStats } from '@/lib/metrics/gifts';
 import type { MoodBucket } from '@/lib/metrics/moodBuckets';
-import PortraitSection from '@/components/PortraitSection';
+import EditableSection from '@/components/EditableSection';
 import MoodTimeline from '@/components/MoodTimeline';
 import StudyMetrics from '@/components/StudyMetrics';
 import GiftHistory from '@/components/GiftHistory';
@@ -72,18 +72,38 @@ export default function PortraitView({
         <div className="space-y-6 lg:col-span-3">
           <Card>
             <div className="space-y-7">
-              <PortraitSection title="Likes" items={portrait.likes} />
-              <PortraitSection title="Dislikes" items={portrait.dislikes} />
-              <PortraitSection title="Jokes" items={portrait.jokes} />
-              <PortraitSection
-                title="Dreams & Wishes"
-                items={portrait.dreams}
+              <EditableSection
+                title="Likes"
+                field="likes"
+                rows={portrait.entries?.likes ?? []}
               />
-              <PortraitSection title="Trips" items={portrait.trips} />
+              <EditableSection
+                title="Dislikes"
+                field="dislikes"
+                rows={portrait.entries?.dislikes ?? []}
+              />
+              <EditableSection
+                title="Jokes"
+                field="jokes"
+                rows={portrait.entries?.jokes ?? []}
+              />
+              <EditableSection
+                title="Dreams & Wishes"
+                field="dreams"
+                rows={portrait.entries?.dreams ?? []}
+              />
+              <EditableSection
+                title="Trips"
+                field="trips"
+                rows={portrait.entries?.trips ?? []}
+              />
             </div>
           </Card>
           <Card title="Gift ledger">
-            <GiftHistory gifts={portrait.gifts} />
+            <GiftHistory
+              gifts={portrait.gifts}
+              rows={portrait.entries?.gifts ?? []}
+            />
           </Card>
         </div>
 

--- a/src/lib/coach/respond.test.ts
+++ b/src/lib/coach/respond.test.ts
@@ -2,17 +2,20 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { prisma } from '@/lib/db'
 import { generate } from '@/lib/ai'
 import { getProfileContext, type ProfileContext } from '@/lib/profile/context'
+import { extractFacts } from '@/lib/extraction/extract'
 import { respond } from './respond'
 
 vi.mock('@/lib/db', () => ({
   prisma: {
-    message: { findMany: vi.fn(), create: vi.fn() },
+    message: {
+      findMany: vi.fn(),
+      create: vi.fn(),
+    },
   },
 }))
 vi.mock('@/lib/ai', () => ({ generate: vi.fn() }))
 vi.mock('@/lib/profile/context', () => ({ getProfileContext: vi.fn() }))
-// @/lib/coach/prompt is NOT mocked: it is pure local code, and mocking it
-// would make these tests pass regardless of what the prompt builder does.
+vi.mock('@/lib/extraction/extract', () => ({ extractFacts: vi.fn() }))
 
 const base: ProfileContext = {
   name: 'Ada',
@@ -33,6 +36,7 @@ describe('respond', () => {
     vi.mocked(prisma.message.findMany).mockResolvedValue([] as never)
     vi.mocked(prisma.message.create).mockResolvedValue({} as never)
     vi.mocked(generate).mockResolvedValue('a thoughtful reply')
+    vi.mocked(extractFacts).mockResolvedValue(0)
   })
 
   it('returns the generated reply', async () => {
@@ -52,12 +56,13 @@ describe('respond', () => {
   })
 
   it('handles a missing profile', async () => {
-    vi.mocked(getProfileContext).mockResolvedValue(null)
+    vi.mocked(getCC).mockResolvedValue(null)
 
     const reply = await respond('p1', 'hi')
 
     expect(reply).toContain('profile')
     expect(generate).not.toHaveBeenCalled()
+    expect(extractFacts).not.toHaveBeenCalled()
   })
 
   it('passes recent history to the prompt', async () => {
@@ -75,4 +80,31 @@ describe('respond', () => {
     const prompt = vi.mocked(generate).mock.lastCall?.[0] ?? ''
     expect(prompt.indexOf('first')).toBeLessThan(prompt.indexOf('second'))
   })
+
+  it('extracts from the user message', async () => {
+    const profileId = 'p1'
+    const userMessage = 'she loved the thai place'
+    await respond(profileId, userMessage)
+
+    expect(extractFacts).toHaveBeenCalledWith(profileId, userMessage)
+  })
+
+  it('extraction failure does not break the reply', async () => {
+    vi.mocked(extractFacts).mockRejectedValue(new Error('extraction failed'))
+
+    const reply = await respond('p1', 'hi')
+
+    expect(reply).toBe('a thoughtful reply')
+  })
+
+  it('no extraction without a profile', async () => {
+    vi.mocked(getProfileContext).mockResolvedValue(null)
+
+    await respond('p1', 'hi')
+
+    expect(extractFacts).not.toHaveBeenCalled()
+  })
 })
+
+// Helper to avoid type errors in the mock setup if needed
+const getCC = getProfileContext

--- a/src/lib/coach/respond.ts
+++ b/src/lib/coach/respond.ts
@@ -2,6 +2,7 @@ import { prisma } from '@/lib/db'
 import { generate } from '@/lib/ai'
 import { getProfileContext } from '@/lib/profile/context'
 import { buildCoachPrompt } from '@/lib/coach/prompt'
+import { extractFacts } from '@/lib/extraction/extract'
 
 export async function respond(
   profileId: string,
@@ -30,6 +31,12 @@ export async function respond(
   await prisma.message.create({
     data: { profileId, role: 'assistant', text: reply },
   })
+
+  try {
+    await extractFacts(profileId, userMessage)
+  } catch {
+    // extraction must never break or delay the reply
+  }
 
   return reply
 }

--- a/src/lib/extraction/extract.test.ts
+++ b/src/lib/extraction/extract.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { prisma } from '@/lib/db'
+import { generate } from '@/lib/ai'
+import { getProfileContext, type ProfileContext } from '@/lib/profile/context'
+import { extractFacts } from './extract'
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    likesEntry: { create: vi.fn() },
+    dislikesEntry: { create: vi.fn() },
+    joke: { create: vi.fn() },
+    mood: { create: vi.fn() },
+    dream: { create: vi.fn() },
+    event: { create: vi.fn() },
+    gift: { create: vi.fn() },
+    trip: { create: vi.fn() },
+  },
+}))
+vi.mock('@/lib/ai', () => ({ generate: vi.fn() }))
+vi.mock('@/lib/profile/context', () => ({ getProfileContext: vi.fn() }))
+// prompt and parse are pure local modules — never mocked.
+
+const base: ProfileContext = {
+  name: 'Ada',
+  likes: [],
+  dislikes: [],
+  jokes: [],
+  dreams: [],
+  recentMoods: [],
+  recentEvents: [],
+  pastGifts: [],
+  pastTrips: [],
+}
+
+const CREATES = () => [
+  prisma.likesEntry.create, prisma.dislikesEntry.create, prisma.joke.create,
+  prisma.mood.create, prisma.dream.create, prisma.event.create,
+  prisma.gift.create, prisma.trip.create,
+]
+
+describe('extractFacts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(getProfileContext).mockResolvedValue(base)
+    for (const fn of CREATES()) vi.mocked(fn).mockResolvedValue({} as never)
+  })
+
+  it('writes an extracted like with provenance', async () => {
+    vi.mocked(generate).mockResolvedValue('{"likes": ["the thai place"]}')
+
+    await expect(extractFacts('p1', 'she loved the thai place')).resolves.toBe(1)
+
+    expect(prisma.likesEntry.create).toHaveBeenCalledWith({
+      data: { profileId: 'p1', text: 'the thai place', source: 'extracted' },
+    })
+  })
+
+  it('unknown profile writes nothing', async () => {
+    vi.mocked(getProfileContext).mockResolvedValue(null)
+
+    await expect(extractFacts('p1', 'hi')).resolves.toBe(0)
+    expect(generate).not.toHaveBeenCalled()
+  })
+
+  it('empty extraction writes nothing', async () => {
+    vi.mocked(generate).mockResolvedValue('{}')
+
+    await expect(extractFacts('p1', 'hi')).resolves.toBe(0)
+    for (const fn of CREATES()) expect(fn).not.toHaveBeenCalled()
+  })
+
+  it('counts across fields', async () => {
+    vi.mocked(generate).mockResolvedValue(
+      '{"moods": ["stressed"], "trips": ["Portugal"]}')
+
+    await expect(extractFacts('p1', 'rough week, dreaming of Portugal')).resolves.toBe(2)
+
+    expect(prisma.mood.create).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ label: 'stressed' }) }))
+    expect(prisma.trip.create).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ destination: 'Portugal' }) }))
+  })
+})

--- a/src/lib/extraction/extract.ts
+++ b/src/lib/extraction/extract.ts
@@ -1,0 +1,92 @@
+import { prisma } from "@/lib/db";
+import { generate } from "@/lib/ai";
+import { getProfileContext } from "@/lib/profile/context";
+import { buildExtractionPrompt } from "@/lib/extraction/prompt";
+import { parseExtraction } from "@/lib/extraction/parse";
+
+export async function extractFacts(profileId: string, text: string): Promise<number> {
+  const context = await getProfileContext(profileId);
+  if (!context) {
+    return 0;
+  }
+
+  const prompt = buildExtractionPrompt(context, text);
+  const rawOutput = await generate(prompt);
+  const extraction = parseExtraction(rawOutput);
+
+  let count = 0;
+
+  if (extraction.likes) {
+    for (const item of extraction.likes) {
+      await prisma.likesEntry.create({
+        data: { profileId, text: item, source: "extracted" },
+      });
+      count++;
+    }
+  }
+
+  if (extraction.dislikes) {
+    for (const item of extraction.dislikes) {
+      await prisma.dislikesEntry.create({
+        data: { profileId, text: item, source: "extracted" },
+      });
+      count++;
+    }
+  }
+
+  if (extraction.jokes) {
+    for (const item of extraction.jokes) {
+      await prisma.joke.create({
+        data: { profileId, text: item, source: "extracted" },
+      });
+      count++;
+    }
+  }
+
+  if (extraction.moods) {
+    for (const item of extraction.moods) {
+      await prisma.mood.create({
+        data: { profileId, label: item, source: "extracted" },
+      });
+      count++;
+    }
+  }
+
+  if (extraction.dreams) {
+    for (const item of extraction.dreams) {
+      await prisma.dream.create({
+        data: { profileId, description: item, source: "extracted" },
+      });
+      count++;
+    }
+  }
+
+  if (extraction.events) {
+    for (const item of extraction.events) {
+      await prisma.event.create({
+        data: { profileId, title: item, occurredAt: new Date(), source: "extracted" },
+      });
+      count++;
+    }
+  }
+
+  if (extraction.gifts) {
+    for (const item of extraction.gifts) {
+      await prisma.gift.create({
+        data: { profileId, description: item, source: "extracted" },
+      });
+      count++;
+    }
+  }
+
+  if (extraction.trips) {
+    for (const item of extraction.trips) {
+      await prisma.trip.create({
+        data: { profileId, destination: item, source: "extracted" },
+      });
+      count++;
+    }
+  }
+
+  return count;
+}

--- a/src/lib/extraction/parse.test.ts
+++ b/src/lib/extraction/parse.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+import { parseExtraction } from './parse'
+
+describe('parse', () => {
+  it('parses fenced JSON and caps at three', () => {
+    const raw = `
+      Here is the data:
+      \`\`\`json
+      {
+        "likes": ["  tea  ", "coffee", "boba", "juice", "milk"],
+        "dislikes": ["rain"]
+      }
+      \`\`\`
+    `
+    const result = parseExtraction(raw)
+    expect(result.likes).toHaveLength(3)
+    expect(result.likes).toEqual(['tea', 'coffee', 'boba'])
+    expect(result.dislikes).toEqual(['rain'])
+  })
+
+  it('malformed input is all-empty', () => {
+    const emptyResult = {
+      likes: [],
+      dislikes: [],
+      jokes: [],
+      dreams: [],
+      moods: [],
+      events: [],
+      gifts: [],
+      trips: [],
+    }
+    expect(parseExtraction('no json here')).toEqual(emptyResult)
+    expect(parseExtraction('{broken')).toEqual(emptyResult)
+    expect(parseExtraction('')).toEqual(emptyResult)
+  })
+
+  it('non-strings and unknown keys are dropped', () => {
+    const raw = JSON.stringify({
+      likes: ['tea', 7, '  ', 'coffee'],
+      hobbies: ['x'],
+      dislikes: [null, 'rain']
+    })
+    const result = parseExtraction(raw)
+    expect(result.likes).toEqual(['tea', 'coffee'])
+    expect(result.dislikes).toEqual(['rain'])
+    // @ts-expect-error - checking runtime behavior for unknown keys
+    expect(result.hobbies).toBeUndefined()
+  })
+
+  it('missing keys become empty arrays', () => {
+    const raw = JSON.stringify({
+      likes: ['tea']
+    })
+    const result = parseExtraction(raw)
+    expect(result.likes).toEqual(['tea'])
+    expect(result.dislikes).toEqual([])
+    expect(result.trips).toEqual([])
+  })
+})

--- a/src/lib/extraction/parse.ts
+++ b/src/lib/extraction/parse.ts
@@ -1,0 +1,50 @@
+export type ExtractedFacts = {
+  likes: string[];
+  dislikes: string[];
+  jokes: string[];
+  dreams: string[];
+  moods: string[];
+  events: string[];
+  gifts: string[];
+  trips: string[];
+};
+
+const EMPTY_FACTS: ExtractedFacts = {
+  likes: [],
+  dislikes: [],
+  jokes: [],
+  dreams: [],
+  moods: [],
+  events: [],
+  gifts: [],
+  trips: [],
+};
+
+export function parseExtraction(raw: string): ExtractedFacts {
+  try {
+    const start = raw.indexOf('{');
+    const end = raw.lastIndexOf('}');
+    if (start === -1 || end === -1 || end < start) return { ...EMPTY_FACTS };
+
+    const parsed = JSON.parse(raw.substring(start, end + 1));
+    const result: ExtractedFacts = { ...EMPTY_FACTS };
+    const keys: (keyof ExtractedFacts)[] = [
+      'likes', 'dislikes', 'jokes', 'dreams', 'moods', 'events', 'gifts', 'trips'
+    ];
+
+    for (const key of keys) {
+      const val = parsed[key];
+      if (Array.isArray(val)) {
+        result[key] = val
+          .filter((item) => typeof item === 'string')
+          .map((s) => s.trim())
+          .filter((s) => s !== '')
+          .slice(0, 3);
+      }
+    }
+
+    return result;
+  } catch {
+    return { ...EMPTY_FACTS };
+  }
+}

--- a/src/lib/extraction/prompt.test.ts
+++ b/src/lib/extraction/prompt.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { buildExtractionPrompt } from './prompt'
+import type { ProfileContext } from '@/lib/profile/context'
+
+describe('prompt', () => {
+  const base: ProfileContext = {
+    name: 'Ada',
+    likes: [],
+    dislikes: [],
+    jokes: [],
+    dreams: [],
+    recentMoods: [],
+    recentEvents: [],
+    pastGifts: [],
+    pastTrips: []
+  }
+
+  it('ends with the message', () => {
+    const message = 'she loved the thai place'
+    const prompt = buildExtractionPrompt(base, message)
+    expect(prompt.endsWith(message)).toBe(true)
+  })
+
+  it('lists known items for dedupe', () => {
+    const context = { ...base, likes: ['tea'] }
+    const prompt = buildExtractionPrompt(context, 'new message')
+    expect(prompt).toContain('Already known likes: tea')
+  })
+
+  it('names the eight keys', () => {
+    const prompt = buildExtractionPrompt(base, 'new message')
+    const keys = ['likes', 'dislikes', 'jokes', 'dreams', 'moods', 'events', 'gifts', 'trips']
+    keys.forEach(key => {
+      expect(prompt).toContain(`"${key}"`) 
+    })
+  })
+})

--- a/src/lib/extraction/prompt.ts
+++ b/src/lib/extraction/prompt.ts
@@ -1,0 +1,26 @@
+import type { ProfileContext } from '@/lib/profile/context';
+
+export function buildExtractionPrompt(context: ProfileContext, message: string): string {
+  const { name, likes, dislikes, jokes, dreams, recentMoods, recentEvents, pastGifts, pastTrips } = context;
+
+  const lines = [
+    `Partner Name: ${name}`
+  ];
+
+  if (likes.length > 0) lines.push(`Already known likes: ${likes.join(', ')}`);
+  if (dislikes.length > 0) lines.push(`Already known dislikes: ${dislikes.join(', ')}`);
+  if (jokes.length > 0) lines.push(`Already known jokes: ${jokes.join(', ')}`);
+  if (dreams.length > 0) lines.push(`Already known dreams: ${dreams.join(', ')}`);
+  if (recentMoods.length > 0) lines.push(`Already known moods: ${recentMoods.join(', ')}`);
+  if (recentEvents.length > 0) lines.push(`Already known events: ${recentEvents.join(', ')}`);
+  if (pastGifts.length > 0) lines.push(`Already known gifts: ${pastGifts.join(', ')}`);
+  if (pastTrips.length > 0) lines.push(`Already known trips: ${pastTrips.join(', ')}`);
+
+  return `Return ONLY a JSON object with exactly these eight keys, each an array of strings: "likes", "dislikes", "jokes", "dreams", "moods", "events", "gifts", "trips".
+
+Extract only facts the user EXPLICITLY stated about their partner in this message; never infer, never invent; return empty arrays when nothing qualifies; at most 3 items per key; do not repeat anything already listed.
+
+${lines.join('\n')}
+
+${message}`;
+}

--- a/src/lib/onboarding/step.test.ts
+++ b/src/lib/onboarding/step.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { prisma } from '@/lib/db'
+import { QUESTIONS } from '@/lib/questionnaire/questions'
+import { onboardingStep } from './step'
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    profile: { findUnique: vi.fn(), update: vi.fn() },
+    questionnaireAnswer: { findMany: vi.fn(), create: vi.fn() },
+    likesEntry: { create: vi.fn() },
+    dislikesEntry: { create: vi.fn() },
+    joke: { create: vi.fn() },
+    mood: { create: vi.fn() },
+    dream: { create: vi.fn() },
+    event: { create: vi.fn() },
+    gift: { create: vi.fn() },
+    trip: { create: vi.fn() },
+  },
+}))
+// questions/flow are pure local modules — never mocked.
+
+const CREATES = () => [
+  prisma.questionnaireAnswer.create, prisma.likesEntry.create,
+  prisma.dislikesEntry.create, prisma.joke.create, prisma.mood.create,
+  prisma.dream.create, prisma.event.create, prisma.gift.create,
+  prisma.trip.create,
+]
+
+describe('onboardingStep', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(prisma.profile.update).mockResolvedValue({} as never)
+    vi.mocked(prisma.questionnaireAnswer.findMany).mockResolvedValue([] as never)
+    vi.mocked(prisma.questionnaireAnswer.create).mockResolvedValue({} as never)
+    vi.mocked(prisma.likesEntry.create).mockResolvedValue({} as never)
+  })
+
+  it('asks for the name first', async () => {
+    vi.mocked(prisma.profile.findUnique).mockResolvedValue(
+      { id: 'p1', name: 'Your person' } as never)
+
+    const reply = await onboardingStep('p1', '')
+
+    expect(reply).toContain('name')
+    for (const fn of CREATES()) expect(fn).not.toHaveBeenCalled()
+  })
+
+  it('stores the name and asks the first question', async () => {
+    vi.mocked(prisma.profile.findUnique).mockResolvedValue(
+      { id: 'p1', name: 'Your person' } as never)
+
+    const reply = await onboardingStep('p1', 'Ada')
+
+    expect(prisma.profile.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ name: 'Ada' }) }))
+    expect(reply).toContain(QUESTIONS[0].prompt)
+  })
+
+  it('stores an answer to its field and asks the next question', async () => {
+    vi.mocked(prisma.profile.findUnique).mockResolvedValue(
+      { id: 'p1', name: 'Ada' } as never)
+
+    const reply = await onboardingStep('p1', 'tea and rainy mornings')
+
+    expect(prisma.questionnaireAnswer.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ questionId: QUESTIONS[0].id }),
+      }))
+    // QUESTIONS[0].field is 'likes'
+    expect(prisma.likesEntry.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          profileId: 'p1',
+          text: 'tea and rainy mornings',
+        }),
+      }))
+    expect(reply).toBe(QUESTIONS[1].prompt)
+  })
+
+  it('hands over to the coach when complete', async () => {
+    vi.mocked(prisma.profile.findUnique).mockResolvedValue(
+      { id: 'p1', name: 'Ada' } as never)
+    vi.mocked(prisma.questionnaireAnswer.findMany).mockResolvedValue(
+      QUESTIONS.map((q) => ({ questionId: q.id })) as never)
+
+    const reply = await onboardingStep('p1', 'anything')
+
+    expect(reply).toBeNull()
+    for (const fn of CREATES()) expect(fn).not.toHaveBeenCalled()
+  })
+})
+
+it('answers carry questionnaire provenance', async () => {
+  // Top-level test: the describe's beforeEach does not apply here.
+  vi.clearAllMocks()
+  vi.mocked(prisma.profile.findUnique).mockResolvedValue(
+    { id: 'p1', name: 'Ada' } as never)
+  vi.mocked(prisma.questionnaireAnswer.findMany).mockResolvedValue([] as never)
+  vi.mocked(prisma.questionnaireAnswer.create).mockResolvedValue({} as never)
+  vi.mocked(prisma.likesEntry.create).mockResolvedValue({} as never)
+
+  await onboardingStep('p1', 'tea and rainy mornings')
+
+  expect(prisma.likesEntry.create).toHaveBeenCalledWith(
+    expect.objectContaining({
+      data: expect.objectContaining({ source: 'questionnaire' }),
+    }))
+})

--- a/src/lib/onboarding/step.ts
+++ b/src/lib/onboarding/step.ts
@@ -1,0 +1,86 @@
+import { prisma } from '@/lib/db'
+import { QUESTIONS, type Question } from '@/lib/questionnaire/questions'
+import { nextQuestion } from '@/lib/questionnaire/flow'
+
+const PLACEHOLDER_NAME = 'Your person'
+
+async function storeAnswer(
+  profileId: string,
+  question: Question,
+  text: string
+): Promise<void> {
+  await prisma.questionnaireAnswer.create({
+    data: { profileId, questionId: question.id, answer: text },
+  })
+  switch (question.field) {
+    case 'likes':
+      await prisma.likesEntry.create({ data: { profileId, text, source: 'questionnaire' } })
+      break
+    case 'dislikes':
+      await prisma.dislikesEntry.create({ data: { profileId, text, source: 'questionnaire' } })
+      break
+    case 'jokes':
+      await prisma.joke.create({ data: { profileId, text, source: 'questionnaire' } })
+      break
+    case 'moods':
+      await prisma.mood.create({ data: { profileId, label: text, source: 'questionnaire' } })
+      break
+    case 'dreams':
+      await prisma.dream.create({ data: { profileId, description: text, source: 'questionnaire' } })
+      break
+    case 'events':
+      await prisma.event.create({
+        data: { profileId, title: text, occurredAt: new Date(), source: 'questionnaire' },
+      })
+      break
+    case 'gifts':
+      await prisma.gift.create({ data: { profileId, description: text, source: 'questionnaire' } })
+      break
+    case 'trips':
+      await prisma.trip.create({ data: { profileId, destination: text, source: 'questionnaire' } })
+      break
+  }
+}
+
+/** The next message the bot should send, or null when onboarding is done. */
+export async function onboardingStep(
+  profileId: string,
+  text: string
+): Promise<string | null> {
+  const trimmed = text.trim()
+
+  const profile = await prisma.profile.findUnique({ where: { id: profileId } })
+  if (profile && profile.name === PLACEHOLDER_NAME) {
+    if (!trimmed) {
+      return 'Welcome to cherish.ai. What is their name?'
+    }
+    await prisma.profile.update({
+      where: { id: profileId },
+      data: { name: trimmed },
+    })
+    return (
+      `${trimmed} it is. Twelve quick questions to start the portrait.\n\n` +
+      QUESTIONS[0].prompt
+    )
+  }
+
+  const answered = await prisma.questionnaireAnswer.findMany({
+    where: { profileId },
+  })
+  const answeredIds = answered.map((a) => a.questionId)
+  const current = nextQuestion(answeredIds)
+  if (current === null) {
+    return null // questionnaire complete: the coach takes it from here
+  }
+
+  await storeAnswer(profileId, current, trimmed)
+  const upNext = nextQuestion([...answeredIds, current.id])
+  if (upNext === null) {
+    return (
+      'That completes the questionnaire — the portrait has its first ' +
+      'layer. From here, just talk to me: tell me how things are going, ' +
+      'and ask whenever you need an idea.'
+    )
+  }
+  return upNext.prompt
+}

--- a/src/lib/portrait/load.test.ts
+++ b/src/lib/portrait/load.test.ts
@@ -83,3 +83,19 @@ describe('load', () => {
     )
   })
 })
+
+it('entries carry ids and provenance', async () => {
+  vi.mocked(prisma.profile.findUnique).mockResolvedValue({
+    name: 'Ada',
+    likes: [{ id: 'l1', text: 'tea', source: 'extracted' }],
+    dislikes: [], jokes: [], dreams: [],
+    trips: [{ id: 't1', destination: 'Kyoto', source: 'manual' }],
+    gifts: [], occasions: [], moods: [], events: [],
+  } as never)
+
+  const portrait = await getPortrait('p1')
+
+  expect(portrait?.entries?.likes[0]).toEqual(
+    { id: 'l1', text: 'tea', source: 'extracted' })
+  expect(portrait?.entries?.trips[0].text).toBe('Kyoto')
+})

--- a/src/lib/portrait/load.ts
+++ b/src/lib/portrait/load.ts
@@ -1,5 +1,24 @@
 import { prisma } from "@/lib/db";
 
+export type EntryRow = { id: string; text: string; source: string };
+
+export type GiftRow = {
+  id: string;
+  description: string;
+  givenAt: Date | null;
+  howItLanded: string | null;
+  source: string;
+};
+
+export type PortraitEntries = {
+  likes: EntryRow[];
+  dislikes: EntryRow[];
+  jokes: EntryRow[];
+  dreams: EntryRow[];
+  trips: EntryRow[];
+  gifts: GiftRow[];
+};
+
 export type Portrait = {
   name: string;
   likes: string[];
@@ -27,6 +46,9 @@ export type Portrait = {
     month: number;
     day: number;
   }[];
+  // Optional by design (two-phase migration): consumers and fixtures that
+  // predate CRUD stay valid; the loader always fills it.
+  entries?: PortraitEntries;
 };
 
 export async function getPortrait(profileId: string): Promise<Portrait | null> {
@@ -54,7 +76,27 @@ export async function getPortrait(profileId: string): Promise<Portrait | null> {
     return null;
   }
 
+  const entryRow = (row: { id: string; source: string }, text: string) => ({
+    id: row.id,
+    text,
+    source: row.source,
+  });
+
   return {
+    entries: {
+      likes: profile.likes.map((l) => entryRow(l, l.text)),
+      dislikes: profile.dislikes.map((d) => entryRow(d, d.text)),
+      jokes: profile.jokes.map((j) => entryRow(j, j.text)),
+      dreams: profile.dreams.map((d) => entryRow(d, d.description)),
+      trips: profile.trips.map((t) => entryRow(t, t.destination)),
+      gifts: profile.gifts.map((g) => ({
+        id: g.id,
+        description: g.description,
+        givenAt: g.givenAt,
+        howItLanded: g.howItLanded,
+        source: g.source,
+      })),
+    },
     name: profile.name,
     likes: profile.likes.map((l) => l.text),
     dislikes: profile.dislikes.map((d) => d.text),


### PR DESCRIPTION
Lands both epics from `dispatch/integration`: **16 stories, 1,182 insertions across 25 files.**

**Gates, `.env.local` moved aside:** 150 tests / 44 files ✅ · tsc ✅ · lint ✅ · build ✅

### Epic 4 — Onboarding
First contact with @cherish_ai_bot now creates and links the profile, asks her name, then walks the twelve questions — each answer stored both as questionnaire progress and as a portrait row. When the twelfth lands, the coach takes over seamlessly.

### Epic 5 — Conversation memory + CRUD
- Every exchange runs a second Haiku pass over YOUR words only: new facts (≤3/field, strict JSON, fail-silent) become portrait rows marked `source: 'extracted'`
- All entries carry provenance (`manual` / `questionnaire` / `extracted`); extracted chips show a subtle `ai` marker
- Every chip is editable in place (Enter saves, Escape cancels) and deletable
- Unrated gifts grow `landed`/`missed` buttons, feeding the success-rate metric

### Provenance of the code itself
9 of 16 ground clean by Spike (including the riskiest wire-in), 4 hand-written after honest strikes, 3 grind-with-token-repairs. Session note: after deploy, run `prisma db push` (or migrate) — the `source` column is new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgUuHL6M6pBwuwozBPFph3