### PR TITLE
Release: restore onboarding (lost to branch reset)

### DIFF
--- a/src/app/api/telegram/route.test.ts
+++ b/src/app/api/telegram/route.test.ts
@@ -1,156 +1,77 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { prisma } from '@/lib/db'
-import type { TelegramChat } from '@prisma/client'
 import { POST } from './route'
 import { sendMessage } from '@/lib/telegram/send'
 import { respond } from '@/lib/coach/respond'
+import { ensureLinkedProfile } from '@/lib/onboarding/link'
+import { onboardingStep } from '@/lib/onboarding/step'
 
-vi.mock('@/lib/db', () => ({
-  prisma: {
-    profile: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
-    likesEntry: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
-    dislikesEntry: { create: vi.fn(), createMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
-    joke: { create: vi.fn(), createMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
-    mood: { create: vi.fn(), createMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
-    event: { create: vi.fn(), createMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
-    gift: { create: vi.fn(), createMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
-    trip: { create: vi.fn(), createMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
-    dream: { create: vi.fn(), createMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
-    suggestion: { create: vi.fn(), createMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
-    telegramChat: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
-    message: { create: vi.fn(), createMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
-    questionnaireAnswer: { create: vi.fn(), createMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
-    occasion: { create: vi.fn(), createMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
-    cadenceRun: { create: vi.fn(), createMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
-    user: { create: vi.fn(), createMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
-    account: { create: vi.fn(), createMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
-    session: { create: vi.fn(), createMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
-    verificationToken: { create: vi.fn(), createMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
-  },
-}))
+vi.mock('@/lib/telegram/send', () => ({ sendMessage: vi.fn() }))
+vi.mock('@/lib/coach/respond', () => ({ respond: vi.fn() }))
+vi.mock('@/lib/onboarding/link', () => ({ ensureLinkedProfile: vi.fn() }))
+vi.mock('@/lib/onboarding/step', () => ({ onboardingStep: vi.fn() }))
+// verify and parse are pure local modules — never mocked; the 401 test
+// proves real rejection, not a mocked one.
 
-vi.mock('@/lib/telegram/send', () => ({
-  sendMessage: vi.fn(),
-}))
+function request(body: unknown, secret?: string): Request {
+  return new Request('http://localhost/api/telegram', {
+    method: 'POST',
+    headers: secret ? { 'x-telegram-bot-api-secret-token': secret } : {},
+    body: JSON.stringify(body),
+  })
+}
 
-vi.mock('@/lib/coach/respond', () => ({
-  respond: vi.fn(),
-}))
+const UPDATE = { message: { chat: { id: 6300285519 }, text: 'hello' } }
 
-const makeTelegramChat = (overrides: Partial<TelegramChat> = {}): TelegramChat =>
-  ({
-    id: '',
-    chatId: '',
-    profileId: '',
-    createdAt: new Date(Date.UTC(2024, 0, 1)),
-    ...overrides,
-  } as unknown as TelegramChat)
-
-describe('route', () => {
-  const WEBHOOK_SECRET = 'super-secret-token'
-  const VALID_HEADER = 'valid-token'
-  const INVALID_HEADER = 'wrong-token'
-
+describe('POST /api/telegram', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    process.env.TELEGRAM_WEBHOOK_SECRET = WEBHOOK_SECRET
+    process.env.TELEGRAM_WEBHOOK_SECRET = 'hooksecret'
+    vi.mocked(ensureLinkedProfile).mockResolvedValue({ profileId: 'p1', created: false })
+    vi.mocked(onboardingStep).mockResolvedValue(null)
+    vi.mocked(respond).mockResolvedValue('a coached reply')
   })
 
   it('rejects a request with the wrong secret', async () => {
-    const request = new Request('https://api.telegram.org/webhook', {
-      method: 'POST',
-      headers: {
-        'x-telegram-bot-api-secret-token': INVALID_HEADER,
-      },
-    })
+    const res = await POST(request(UPDATE, 'wrong'))
 
-    const response = await POST(request)
-    expect(response.status).toBe(401)
+    expect(res.status).toBe(401)
     expect(respond).not.toHaveBeenCalled()
+    expect(sendMessage).not.toHaveBeenCalled()
   })
 
   it('acknowledges a non-text update', async () => {
-    // We use a payload that parseUpdate will return null for (e.g. an unhandled update type)
-    // Since parseUpdate is not mocked, we rely on its real behavior. 
-    // For this test, we provide a valid JSON that doesn't contain a message.text
-    const request = new Request('https://api.telegram.im/webhook', {
-      method: 'POST',
-      headers: {
-        'x-telegram-bot-api-secret-token': WEBHOOK_SECRET,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        update_id: 12345,
-        // No message object, so parseUpdate should return null
-      }),
-    })
+    const res = await POST(request({ message: { chat: { id: 1 }, photo: [] } }, 'hooksecret'))
 
-    const response = await POST(request)
-    const body = await response.json()
-
-    expect(response.status).toBe(200)
-    expect(body).toEqual({ ok: true })
+    expect(res.status).toBe(200)
     expect(respond).not.toHaveBeenCalled()
   })
 
-  it('replies to a known chat', async () => {
-    const chatId = '12345'
-    const text = 'Hello Coach!'
-    const profileId = 'p1'
-    const replyText = 'Hello back!'
+  it('replies to a known chat via the coach', async () => {
+    const res = await POST(request(UPDATE, 'hooksecret'))
 
-    const request = new Request('https://api.telegram.org/webhook', {
-      method: 'POST',
-      headers: {
-        'x-telegram-bot-api-secret-token': WEBHOOK_SECRET,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        message: {
-          chat: { id: chatId },
-          text: text,
-        },
-      }),
-    })
-
-    vi.mocked(prisma.telegramChat.findUnique).mockResolvedValue(makeTelegramChat({ chatId, profileId }))
-    vi.mocked(respond).mockResolvedValue(replyText)
-
-    const response = await POST(request)
-    const body = await response.json()
-
-    expect(response.status).toBe(200)
-    expect(body).toEqual({ ok: true })
-    expect(respond).toHaveBeenCalledWith(profileId, text)
-    expect(sendMessage).toHaveBeenCalledWith(chatId, replyText)
+    expect(res.status).toBe(200)
+    expect(respond).toHaveBeenCalledWith('p1', 'hello')
+    expect(sendMessage).toHaveBeenCalledWith('6300285519', 'a coached reply')
   })
 
-  it('prompts an unknown chat to link', async () => {
-    const chatId = '99999'
-    const text = 'Hi'
+  it('first contact starts onboarding', async () => {
+    vi.mocked(ensureLinkedProfile).mockResolvedValue({ profileId: 'p9', created: true })
+    vi.mocked(onboardingStep).mockResolvedValue('Welcome to cherish.ai. What is their name?')
 
-    const request = new Request('https://api.telegram.org/webhook', {
-      method: 'POST',
-  		headers: {
-  			'x-telegram-bot-api-secret-token': WEBHOOK_SECRET,
-  			'Content-Type': 'application/json',
-  		},
-  		body: JSON.stringify({
-  			message: {
-  				chat: { id: chatId },
-  				text: text,
-  			},
-  		}),
-    })
+    const res = await POST(request(UPDATE, 'hooksecret'))
 
-    vi.mocked(prisma.telegramChat.findUnique).mockResolvedValue(null)
-
-    const response = await POST(request)
-    const body = await response.json()
-
-    expect(response.status).toBe(200)
-    expect(body).toEqual({ ok: true })
+    expect(res.status).toBe(200)
+    expect(sendMessage).toHaveBeenCalledWith(
+      '6300285519', 'Welcome to cherish.ai. What is their name?')
     expect(respond).not.toHaveBeenCalled()
-    expect(sendMessage).toHaveBeenCalledWith(chatId, "Please link your Telegram account to use this bot.")
+  })
+
+  it('mid-questionnaire messages get the next question', async () => {
+    vi.mocked(onboardingStep).mockResolvedValue('Question 2?')
+
+    await POST(request(UPDATE, 'hooksecret'))
+
+    expect(sendMessage).toHaveBeenCalledWith('6300285519', 'Question 2?')
+    expect(respond).not.toHaveBeenCalled()
   })
 })

--- a/src/app/api/telegram/route.ts
+++ b/src/app/api/telegram/route.ts
@@ -2,44 +2,35 @@ import { verifyTelegramSecret } from '@/lib/telegram/verify';
 import { parseUpdate } from '@/lib/telegram/parse';
 import { sendMessage } from '@/lib/telegram/send';
 import { respond } from '@/lib/coach/respond';
-import { prisma } from '@/lib/db';
+import { ensureLinkedProfile } from '@/lib/onboarding/link';
+import { onboardingStep } from '@/lib/onboarding/step';
 
 export async function POST(request: Request): Promise<Response> {
   const secretToken = request.headers.get('x-telegram-bot-api-secret-token');
-  const webhookSecret = process.env.TELEGRAM_WEBHOOK_SECRET;
-
-  if (!secretToken || !webhookSecret || !(await verifyTelegramSecret(secretToken, webhookSecret))) {
-    return new Response(null, { status: 401 });
+  if (!verifyTelegramSecret(secretToken, process.env.TELEGRAM_WEBHOOK_SECRET)) {
+    return new Response(JSON.stringify({ ok: false }), { status: 401 });
   }
 
-  let update;
-  try {
-    update = await request.json();
-  } catch (err) {
-    return new Response(null, { status: 400 });
-  }
-
+  const update = await request.json();
   const parsed = parseUpdate(update);
+  // Telegram retries any non-2xx forever; unhandled update kinds are
+  // acknowledged, not refused.
   if (!parsed) {
     return new Response(JSON.stringify({ ok: true }), { status: 200 });
   }
 
   const { chatId, text } = parsed;
 
-  if (!text) {
+  // First contact begins onboarding — nobody is told to "link an account".
+  const { profileId } = await ensureLinkedProfile(chatId);
+
+  const onboarding = await onboardingStep(profileId, text);
+  if (onboarding !== null) {
+    await sendMessage(chatId, onboarding);
     return new Response(JSON.stringify({ ok: true }), { status: 200 });
   }
 
-  const chat = await prisma.telegramChat.findUnique({
-    where: { chatId },
-  });
-
-  if (!chat) {
-    await sendMessage(chatId, "Please link your Telegram account to use this bot.");
-    return new Response(JSON.stringify({ ok: true }), { status: 200 });
-  }
-
-  const replyText = await respond(chat.profileId, text);
+  const replyText = await respond(profileId, text);
   await sendMessage(chatId, replyText);
 
   return new Response(JSON.stringify({ ok: true }), { status: 200 });

--- a/src/lib/onboarding/link.test.ts
+++ b/src/lib/onboarding/link.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ensureLinkedProfile } from './link'
+import { prisma as db } from '@/lib/db'
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    telegramChat: {
+      findUnique: vi.fn(),
+      create: vi.fn(),
+    },
+    profile: {
+      findFirst: vi.fn(),
+      create: vi.fn(),
+    },
+  },
+}))
+
+describe('link', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns the existing link without writing', async () => {
+    vi.mocked(db.telegramChat.findUnique).mockResolvedValue({
+      id: 'chat-123',
+      chatId: '42',
+      profileId: 'p1',
+      createdAt: new Date(Date.UTC(2024, 0, 1)),
+    } as any)
+
+    const result = await ensureLinkedProfile('42')
+
+    expect(result).toEqual({ profileId: 'p1', created: false })
+    expect(db.telegramChat.create).not.toHaveBeenCalled()
+  })
+
+  it('links an existing profile', async () => {
+    vi.mocked(db.telegramChat.findUnique).mockResolvedValue(null as any)
+    vi.mocked(db.profile.findFirst).mockResolvedValue({
+      id: 'p1',
+      name: 'Existing',
+    } as any)
+    vi.mocked(db.telegramChat.create).mockResolvedValue({ id: 'chat-42' } as any)
+
+    const result = await ensureLinkedProfile('42')
+
+    expect(db.telegramChat.create).toHaveBeenCalledWith({
+      data: { chatId: '42', profileId: 'p1' },
+    })
+    expect(result.created).toBe(true)
+    expect(result.profileId).toBe('p1')
+  })
+
+  it('creates the profile when none exists', async () => {
+    vi.mocked(db.telegramChat.findUnique).mockResolvedValue(null as any)
+    vi.mocked(db.profile.findFirst).mockResolvedValue(null as any)
+    vi.mocked(db.profile.create).mockResolvedValue({
+      id: 'p2',
+      name: 'Your person',
+    } as any)
+    vi.mocked(db.telegramChat.create).mockResolvedValue({ id: 'chat-42' } as any)
+
+    const result = await ensureLinkedProfile('42')
+
+    expect(db.profile.create).toHaveBeenCalledWith({
+      data: { name: 'Your person' },
+    })
+    expect(result.profileId).toBe('p2')
+    expect(result.created).toBe(true)
+  })
+})

--- a/src/lib/onboarding/link.ts
+++ b/src/lib/onboarding/link.ts
@@ -1,0 +1,28 @@
+import { prisma } from '@/lib/db';
+
+export async function ensureLinkedProfile(chatId: string): Promise<{ profileId: string; created: boolean }> {
+  const existingChat = await prisma.telegramChat.findUnique({
+    where: { chatId },
+  });
+
+  if (existingChat) {
+    return { profileId: existingChat.profileId, created: false };
+  }
+
+  let profile = await prisma.profile.findFirst();
+
+  if (!profile) {
+    profile = await prisma.profile.create({
+      data: { name: 'Your person' },
+    });
+  }
+
+  await prisma.telegramChat.create({
+    data: {
+      chatId,
+      profileId: profile.id,
+    },
+  });
+
+  return { profileId: profile.id, created: true };
+}


### PR DESCRIPTION
The #142 restoration: onboarding route + link module back on the build. After this deploys, first contact actually asks her name and the twelve questions run.

⚠️ Merge with a merge commit, never squash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgUuHL6M6pBwuwozBPFph3