### PR TITLE
Conversational onboarding — understanding is model work

### DIFF
--- a/src/lib/onboarding/step.test.ts
+++ b/src/lib/onboarding/step.test.ts
@@ -86,6 +86,20 @@ describe('onboardingStep', () => {
     expect(reply).toContain(QUESTIONS[1].prompt)
   })
 
+  it('a question back is conversed with, not filed as an answer', async () => {
+    vi.mocked(prisma.profile.findUnique).mockResolvedValue(
+      { id: 'p1', name: 'Yoyo' } as never)
+    vi.mocked(generate)
+      .mockResolvedValueOnce('CHAT')  // turn understanding
+      .mockResolvedValueOnce('')      // voice falls back
+
+    const reply = await onboardingStep('p1', 'why do you need to know that?')
+
+    expect(prisma.questionnaireAnswer.create).not.toHaveBeenCalled()
+    expect(extractFacts).not.toHaveBeenCalled()
+    expect(reply).toContain(QUESTIONS[0].prompt)
+  })
+
   it('extraction failure never wedges the questionnaire', async () => {
     vi.mocked(prisma.profile.findUnique).mockResolvedValue(
       { id: 'p1', name: 'Yoyo' } as never)

--- a/src/lib/onboarding/step.test.ts
+++ b/src/lib/onboarding/step.test.ts
@@ -1,108 +1,111 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { prisma } from '@/lib/db'
+import { generate } from '@/lib/ai'
+import { extractFacts } from '@/lib/extraction/extract'
 import { QUESTIONS } from '@/lib/questionnaire/questions'
 import { onboardingStep } from './step'
 
 vi.mock('@/lib/db', () => ({
   prisma: {
     profile: { findUnique: vi.fn(), update: vi.fn() },
-    questionnaireAnswer: { findMany: vi.fn(), create: vi.fn() },
-    likesEntry: { create: vi.fn() },
-    dislikesEntry: { create: vi.fn() },
-    joke: { create: vi.fn() },
-    mood: { create: vi.fn() },
-    dream: { create: vi.fn() },
-    event: { create: vi.fn() },
-    gift: { create: vi.fn() },
-    trip: { create: vi.fn() },
+    questionnaireAnswer: { findMany: vi.fn(), findFirst: vi.fn(), create: vi.fn() },
   },
 }))
+vi.mock('@/lib/ai', () => ({ generate: vi.fn() }))
+vi.mock('@/lib/extraction/extract', () => ({ extractFacts: vi.fn() }))
 // questions/flow are pure local modules — never mocked.
-
-const CREATES = () => [
-  prisma.questionnaireAnswer.create, prisma.likesEntry.create,
-  prisma.dislikesEntry.create, prisma.joke.create, prisma.mood.create,
-  prisma.dream.create, prisma.event.create, prisma.gift.create,
-  prisma.trip.create,
-]
 
 describe('onboardingStep', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.mocked(prisma.profile.update).mockResolvedValue({} as never)
     vi.mocked(prisma.questionnaireAnswer.findMany).mockResolvedValue([] as never)
+    vi.mocked(prisma.questionnaireAnswer.findFirst).mockResolvedValue(null)
     vi.mocked(prisma.questionnaireAnswer.create).mockResolvedValue({} as never)
-    vi.mocked(prisma.likesEntry.create).mockResolvedValue({} as never)
+    vi.mocked(extractFacts).mockResolvedValue(0)
+    // Default voice: the model hiccups, fallbacks carry the flow.
+    vi.mocked(generate).mockResolvedValue('')
   })
 
-  it('asks for the name first', async () => {
+  it('a first greeting earns the name question, not a name', async () => {
     vi.mocked(prisma.profile.findUnique).mockResolvedValue(
       { id: 'p1', name: 'Your person' } as never)
 
-    const reply = await onboardingStep('p1', '')
+    const reply = await onboardingStep('p1', 'Hi')
 
     expect(reply).toContain('name')
-    for (const fn of CREATES()) expect(fn).not.toHaveBeenCalled()
+    expect(prisma.profile.update).not.toHaveBeenCalled()
+    expect(prisma.questionnaireAnswer.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ questionId: 'partner-name' }),
+      }))
   })
 
-  it('stores the name and asks the first question', async () => {
+  it('extracts the name from a conversational reply', async () => {
     vi.mocked(prisma.profile.findUnique).mockResolvedValue(
       { id: 'p1', name: 'Your person' } as never)
+    vi.mocked(prisma.questionnaireAnswer.findFirst).mockResolvedValue(
+      { id: 'm1', questionId: 'partner-name' } as never)
+    vi.mocked(generate)
+      .mockResolvedValueOnce('Yoyo')  // name extraction
+      .mockResolvedValueOnce('')      // voice falls back
 
-    const reply = await onboardingStep('p1', 'Ada')
+    const reply = await onboardingStep('p1', 'Her name is Yoyo')
 
     expect(prisma.profile.update).toHaveBeenCalledWith(
-      expect.objectContaining({ data: expect.objectContaining({ name: 'Ada' }) }))
+      expect.objectContaining({ data: expect.objectContaining({ name: 'Yoyo' }) }))
     expect(reply).toContain(QUESTIONS[0].prompt)
   })
 
-  it('stores an answer to its field and asks the next question', async () => {
+  it('a correction is not a name — it earns a re-ask', async () => {
     vi.mocked(prisma.profile.findUnique).mockResolvedValue(
-      { id: 'p1', name: 'Ada' } as never)
+      { id: 'p1', name: 'Your person' } as never)
+    vi.mocked(prisma.questionnaireAnswer.findFirst).mockResolvedValue(
+      { id: 'm1', questionId: 'partner-name' } as never)
+    vi.mocked(generate)
+      .mockResolvedValueOnce('NONE')  // extraction sees no name given
+      .mockResolvedValueOnce('')      // voice falls back
 
-    const reply = await onboardingStep('p1', 'tea and rainy mornings')
+    const reply = await onboardingStep('p1', 'No her name is not Hi')
+
+    expect(prisma.profile.update).not.toHaveBeenCalled()
+    expect(reply).toContain('name')
+  })
+
+  it('an answer records progress and feeds extraction', async () => {
+    vi.mocked(prisma.profile.findUnique).mockResolvedValue(
+      { id: 'p1', name: 'Yoyo' } as never)
+
+    const reply = await onboardingStep('p1', 'she loves gardening and old films')
 
     expect(prisma.questionnaireAnswer.create).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({ questionId: QUESTIONS[0].id }),
       }))
-    // QUESTIONS[0].field is 'likes'
-    expect(prisma.likesEntry.create).toHaveBeenCalledWith(
-      expect.objectContaining({
-        data: expect.objectContaining({
-          profileId: 'p1',
-          text: 'tea and rainy mornings',
-        }),
-      }))
-    expect(reply).toBe(QUESTIONS[1].prompt)
+    expect(extractFacts).toHaveBeenCalledWith('p1', 'she loves gardening and old films')
+    expect(reply).toContain(QUESTIONS[1].prompt)
+  })
+
+  it('extraction failure never wedges the questionnaire', async () => {
+    vi.mocked(prisma.profile.findUnique).mockResolvedValue(
+      { id: 'p1', name: 'Yoyo' } as never)
+    vi.mocked(extractFacts).mockRejectedValue(new Error('model down'))
+
+    const reply = await onboardingStep('p1', 'she loves gardening')
+
+    expect(prisma.questionnaireAnswer.create).toHaveBeenCalled()
+    expect(reply).toContain(QUESTIONS[1].prompt)
   })
 
   it('hands over to the coach when complete', async () => {
     vi.mocked(prisma.profile.findUnique).mockResolvedValue(
-      { id: 'p1', name: 'Ada' } as never)
+      { id: 'p1', name: 'Yoyo' } as never)
     vi.mocked(prisma.questionnaireAnswer.findMany).mockResolvedValue(
       QUESTIONS.map((q) => ({ questionId: q.id })) as never)
 
     const reply = await onboardingStep('p1', 'anything')
 
     expect(reply).toBeNull()
-    for (const fn of CREATES()) expect(fn).not.toHaveBeenCalled()
+    expect(extractFacts).not.toHaveBeenCalled()
   })
-})
-
-it('answers carry questionnaire provenance', async () => {
-  // Top-level test: the describe's beforeEach does not apply here.
-  vi.clearAllMocks()
-  vi.mocked(prisma.profile.findUnique).mockResolvedValue(
-    { id: 'p1', name: 'Ada' } as never)
-  vi.mocked(prisma.questionnaireAnswer.findMany).mockResolvedValue([] as never)
-  vi.mocked(prisma.questionnaireAnswer.create).mockResolvedValue({} as never)
-  vi.mocked(prisma.likesEntry.create).mockResolvedValue({} as never)
-
-  await onboardingStep('p1', 'tea and rainy mornings')
-
-  expect(prisma.likesEntry.create).toHaveBeenCalledWith(
-    expect.objectContaining({
-      data: expect.objectContaining({ source: 'questionnaire' }),
-    }))
 })

--- a/src/lib/onboarding/step.ts
+++ b/src/lib/onboarding/step.ts
@@ -30,6 +30,26 @@ async function extractName(text: string): Promise<string | null> {
   }
 }
 
+/** Is this turn an answer to the question, or the user talking TO the bot?
+ *
+ * Mid-questionnaire people ask things back ("why do you ask?"), and a
+ * question filed as an answer corrupts the portrait. On any doubt or model
+ * failure the verdict is 'answer' — progress bias, since a wrong 'chat'
+ * verdict would loop the same question forever.
+ */
+async function turnKind(question: string, reply: string): Promise<'answer' | 'chat'> {
+  try {
+    const raw = await generate(
+      `A user was asked: "${question}"\nThey wrote: "${reply}"\n\nIs their ` +
+      'message an ANSWER to the question, or are they asking something or ' +
+      'chatting with the assistant instead? Reply with exactly one word: ' +
+      'ANSWER or CHAT.')
+    return /^\s*chat\b/i.test(raw) ? 'chat' : 'answer'
+  } catch {
+    return 'answer'
+  }
+}
+
 /** A conversational line, with a plain fallback so onboarding never wedges
  * on a model hiccup. */
 async function say(instruction: string, fallback: string): Promise<string> {
@@ -93,6 +113,17 @@ export async function onboardingStep(
   const current = nextQuestion(answeredIds)
   if (current === null) {
     return null // questionnaire complete: the coach takes it from here
+  }
+
+  // Understand the turn before filing it.
+  if ((await turnKind(current.prompt, trimmed)) === 'chat') {
+    return say(
+      `You are a warm relationship coach in the middle of intake questions ` +
+      `about the user's partner. You asked: "${current.prompt}". Instead of ` +
+      `answering, the user said: "${trimmed}". Respond helpfully to what ` +
+      `they said in one or two short sentences, then gently return to the ` +
+      `question.`,
+      `Good question! ${current.prompt}`)
   }
 
   // Progress first — extraction may fail, and a wedged questionnaire is

--- a/src/lib/onboarding/step.ts
+++ b/src/lib/onboarding/step.ts
@@ -1,44 +1,43 @@
 import { prisma } from '@/lib/db'
-import { QUESTIONS, type Question } from '@/lib/questionnaire/questions'
+import { generate } from '@/lib/ai'
+import { QUESTIONS } from '@/lib/questionnaire/questions'
 import { nextQuestion } from '@/lib/questionnaire/flow'
+import { extractFacts } from '@/lib/extraction/extract'
 
 const PLACEHOLDER_NAME = 'Your person'
+// Reserved progress marker: unknown ids are ignored by nextQuestion, so it
+// never counts toward the twelve.
+const NAME_MARKER = 'partner-name'
 
-async function storeAnswer(
-  profileId: string,
-  question: Question,
-  text: string
-): Promise<void> {
-  await prisma.questionnaireAnswer.create({
-    data: { profileId, questionId: question.id, answer: text },
-  })
-  switch (question.field) {
-    case 'likes':
-      await prisma.likesEntry.create({ data: { profileId, text, source: 'questionnaire' } })
-      break
-    case 'dislikes':
-      await prisma.dislikesEntry.create({ data: { profileId, text, source: 'questionnaire' } })
-      break
-    case 'jokes':
-      await prisma.joke.create({ data: { profileId, text, source: 'questionnaire' } })
-      break
-    case 'moods':
-      await prisma.mood.create({ data: { profileId, label: text, source: 'questionnaire' } })
-      break
-    case 'dreams':
-      await prisma.dream.create({ data: { profileId, description: text, source: 'questionnaire' } })
-      break
-    case 'events':
-      await prisma.event.create({
-        data: { profileId, title: text, occurredAt: new Date(), source: 'questionnaire' },
-      })
-      break
-    case 'gifts':
-      await prisma.gift.create({ data: { profileId, description: text, source: 'questionnaire' } })
-      break
-    case 'trips':
-      await prisma.trip.create({ data: { profileId, destination: text, source: 'questionnaire' } })
-      break
+/** The name being GIVEN in a reply, or null when there isn't one.
+ *
+ * "Hi" became the partner's name in production; the deterministic fix
+ * (a greeting blocklist) still read "No her name is not Hi" as an answer to
+ * question one. Understanding a reply is model work.
+ */
+async function extractName(text: string): Promise<string | null> {
+  try {
+    const raw = await generate(
+      "The user was asked for their partner's first name. From their reply, " +
+      'extract the name being given. Reply with ONLY the name — or the word ' +
+      'NONE if no name is actually being given (a greeting, a question, or a ' +
+      `correction is not a name).\n\nTheir reply: "${text}"`)
+    const name = raw.trim().split(/\s+/).slice(0, 3).join(' ').replace(/["'.]/g, '')
+    if (!name || /^none$/i.test(name) || name.length > 40) return null
+    return name
+  } catch {
+    return null
+  }
+}
+
+/** A conversational line, with a plain fallback so onboarding never wedges
+ * on a model hiccup. */
+async function say(instruction: string, fallback: string): Promise<string> {
+  try {
+    const out = (await generate(instruction)).trim()
+    return out || fallback
+  } catch {
+    return fallback
   }
 }
 
@@ -51,17 +50,40 @@ export async function onboardingStep(
 
   const profile = await prisma.profile.findUnique({ where: { id: profileId } })
   if (profile && profile.name === PLACEHOLDER_NAME) {
-    if (!trimmed) {
-      return 'Welcome to cherish.ai. What is their name?'
+    const asked = await prisma.questionnaireAnswer.findFirst({
+      where: { profileId, questionId: NAME_MARKER },
+    })
+    if (!asked) {
+      await prisma.questionnaireAnswer.create({
+        data: { profileId, questionId: NAME_MARKER, answer: '' },
+      })
+      return say(
+        'You are a warm relationship coach called cherish.ai, meeting a new ' +
+        'user. In one or two short sentences: welcome them, say you will ' +
+        'help them study and delight their partner, and ask for their ' +
+        "partner's name.",
+        "Welcome to cherish.ai — I'm here to help you study and delight " +
+        'your partner. What is their name?')
+    }
+    const name = await extractName(trimmed)
+    if (!name) {
+      return say(
+        'You are a warm relationship coach. The user has not told you their ' +
+        `partner's name yet — their last message was: "${trimmed}". In one ` +
+        'short friendly sentence, ask again for the name.',
+        "I didn't catch it — what is their name?")
     }
     await prisma.profile.update({
       where: { id: profileId },
-      data: { name: trimmed },
+      data: { name },
     })
-    return (
-      `${trimmed} it is. Twelve quick questions to start the portrait.\n\n` +
-      QUESTIONS[0].prompt
-    )
+    const first = QUESTIONS[0].prompt
+    return say(
+      `You are a warm relationship coach. The user just told you their ` +
+      `partner is called ${name}. In one short sentence acknowledge the ` +
+      `name warmly, mention you have twelve quick questions to start their ` +
+      `portrait, then ask exactly this question: "${first}"`,
+      `${name} it is. Twelve quick questions to start the portrait.\n\n${first}`)
   }
 
   const answered = await prisma.questionnaireAnswer.findMany({
@@ -73,14 +95,34 @@ export async function onboardingStep(
     return null // questionnaire complete: the coach takes it from here
   }
 
-  await storeAnswer(profileId, current, trimmed)
+  // Progress first — extraction may fail, and a wedged questionnaire is
+  // worse than a thin answer. The raw text is kept on the answer row; the
+  // portrait rows come from the same extraction pipeline the coach uses,
+  // so one honest rambling answer can feed several fields.
+  await prisma.questionnaireAnswer.create({
+    data: { profileId, questionId: current.id, answer: trimmed },
+  })
+  try {
+    await extractFacts(profileId, trimmed)
+  } catch {
+    // fail-silent by design
+  }
+
   const upNext = nextQuestion([...answeredIds, current.id])
   if (upNext === null) {
-    return (
+    return say(
+      'You are a warm relationship coach. The user just finished a twelve-' +
+      'question intake about their partner. In two short sentences: tell ' +
+      'them the questionnaire is complete and the portrait has its first ' +
+      'layer, and invite them to just talk to you from here on.',
       'That completes the questionnaire — the portrait has its first ' +
       'layer. From here, just talk to me: tell me how things are going, ' +
-      'and ask whenever you need an idea.'
-    )
+      'and ask whenever you need an idea.')
   }
-  return upNext.prompt
+  return say(
+    `You are a warm relationship coach walking a user through intake ` +
+    `questions about their partner. They just answered: "${trimmed}". In ` +
+    `one short sentence acknowledge their answer, then ask exactly this ` +
+    `question: "${upNext.prompt}"`,
+    upNext.prompt)
 }


### PR DESCRIPTION
Production transcript: "Hi" became her name, and the correction became question one's answer. The fix keeps the deterministic skeleton (progress, sequencing, fallbacks) and moves comprehension to Haiku: names are extracted from natural phrasing, answers feed the extraction pipeline (one rambling answer can fill several fields), and every bot line is model-composed with a plain fallback so nothing can wedge.

**155 tests ✅ tsc ✅ lint ✅**

After merge+deploy I'll scrub the junk rows ('Hi' as name, the mis-filed answer) so onboarding restarts clean mid-conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgUuHL6M6pBwuwozBPFph3