### PR TITLE
Gifts in the Add-to form; 'Add to the Portrait'

### DIFF
--- a/src/app/actions/addEntry.test.ts
+++ b/src/app/actions/addEntry.test.ts
@@ -9,6 +9,7 @@ vi.mock('@/lib/db', () => ({
     dislikesEntry: { create: vi.fn() },
     joke: { create: vi.fn() },
     dream: { create: vi.fn() },
+    gift: { create: vi.fn() },
   },
 }))
 
@@ -57,5 +58,17 @@ describe('addEntry', () => {
 
     expect(res).toEqual({ ok: false })
     expect(prisma.likesEntry.create).not.toHaveBeenCalled()
+  })
+})
+
+it('a gift stores description', async () => {
+  vi.clearAllMocks()
+  vi.mocked(prisma.gift.create).mockResolvedValue({} as never)
+
+  const result = await addEntry('p1', 'gifts', 'a pottery wheel')
+
+  expect(result).toEqual({ ok: true })
+  expect(prisma.gift.create).toHaveBeenCalledWith({
+    data: { profileId: 'p1', description: 'a pottery wheel' },
   })
 })

--- a/src/app/actions/addEntry.ts
+++ b/src/app/actions/addEntry.ts
@@ -3,7 +3,7 @@
 import { prisma } from '@/lib/db'
 import { revalidatePath } from 'next/cache'
 
-const FIELDS = ['likes', 'dislikes', 'jokes', 'dreams'] as const
+const FIELDS = ['likes', 'dislikes', 'jokes', 'dreams', 'gifts'] as const
 export type EntryField = typeof FIELDS[number]
 
 export async function addEntry(
@@ -25,6 +25,8 @@ export async function addEntry(
     await prisma.joke.create({ data: { profileId, text: trimmedText } })
   } else if (field === 'dreams') {
     await prisma.dream.create({ data: { profileId, description: trimmedText } })
+  } else if (field === 'gifts') {
+    await prisma.gift.create({ data: { profileId, description: trimmedText } })
   }
 
   revalidatePath('/portrait')

--- a/src/components/EntryForm.tsx
+++ b/src/components/EntryForm.tsx
@@ -35,6 +35,7 @@ export default function EntryForm({ profileId }: { profileId: string }) {
           <option value="dislikes">dislikes</option>
           <option value="jokes">jokes</option>
           <option value="dreams">dreams</option>
+          <option value="gifts">gifts</option>
         </select>
       </div>
 

--- a/src/components/PortraitView.tsx
+++ b/src/components/PortraitView.tsx
@@ -111,7 +111,7 @@ export default function PortraitView({
           <Card title="Moods, lately">
             <MoodTimeline buckets={buckets} />
           </Card>
-          <Card title="Add to the study">
+          <Card title="Add to the Portrait">
             <div className="space-y-8">
               <MoodForm profileId={profileId} />
               <div className="h-px bg-line" />


### PR DESCRIPTION
- The `Add to` select gains **gifts** (stores `Gift.description`, shows in the ledger as unrated — ready for a landed/missed verdict later)
- Card title: "Add to the study" → **"Add to the Portrait"**

Gates: full suite ✅ tsc ✅ lint ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgUuHL6M6pBwuwozBPFph3