### PR TITLE
Occasions card (birthday/anniversary) + deletable gifts

### DIFF
--- a/src/app/actions/addOccasion.test.ts
+++ b/src/app/actions/addOccasion.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { prisma } from '@/lib/db'
+import { revalidatePath } from 'next/cache'
+import { addOccasion } from './addOccasion'
+
+vi.mock('@/lib/db', () => ({ prisma: { occasion: { create: vi.fn() } } }))
+vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }))
+
+describe('addOccasion', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(prisma.occasion.create).mockResolvedValue({} as never)
+  })
+
+  it('creates an occasion and revalidates', async () => {
+    const result = await addOccasion('p1', 'birthday', 'her birthday', 9, 4)
+
+    expect(result).toEqual({ ok: true })
+    expect(prisma.occasion.create).toHaveBeenCalledWith({
+      data: { profileId: 'p1', kind: 'birthday', label: 'her birthday', month: 9, day: 4 },
+    })
+    expect(revalidatePath).toHaveBeenCalledWith('/portrait')
+  })
+
+  it('rejects an impossible date without a db call', async () => {
+    expect(await addOccasion('p1', 'birthday', 'x', 13, 4)).toEqual({ ok: false })
+    expect(await addOccasion('p1', 'birthday', 'x', 2, 31)).toEqual({ ok: false })
+    expect(prisma.occasion.create).not.toHaveBeenCalled()
+  })
+
+  it('rejects an empty label', async () => {
+    expect(await addOccasion('p1', 'anniversary', '  ', 6, 12)).toEqual({ ok: false })
+    expect(prisma.occasion.create).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/actions/addOccasion.ts
+++ b/src/app/actions/addOccasion.ts
@@ -1,0 +1,26 @@
+'use server'
+
+import { prisma } from '@/lib/db'
+import { revalidatePath } from 'next/cache'
+
+const DAYS_IN_MONTH = [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+
+export async function addOccasion(
+  profileId: string,
+  kind: string,
+  label: string,
+  month: number,
+  day: number
+): Promise<{ ok: boolean }> {
+  const trimmed = label.trim()
+  if (!trimmed) return { ok: false }
+  if (!Number.isInteger(month) || month < 1 || month > 12) return { ok: false }
+  if (!Number.isInteger(day) || day < 1 || day > DAYS_IN_MONTH[month - 1]) {
+    return { ok: false }
+  }
+  await prisma.occasion.create({
+    data: { profileId, kind, label: trimmed, month, day },
+  })
+  revalidatePath('/portrait')
+  return { ok: true }
+}

--- a/src/app/actions/editEntry.test.ts
+++ b/src/app/actions/editEntry.test.ts
@@ -10,12 +10,14 @@ vi.mock('@/lib/db', () => ({
     joke: { update: vi.fn(), delete: vi.fn() },
     dream: { update: vi.fn(), delete: vi.fn() },
     trip: { update: vi.fn(), delete: vi.fn() },
+    gift: { update: vi.fn(), delete: vi.fn() },
   },
 }))
 vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }))
 
 const MODELS = () => [
   prisma.likesEntry, prisma.dislikesEntry, prisma.joke, prisma.dream, prisma.trip,
+  prisma.gift,
 ]
 
 describe('editEntry', () => {
@@ -58,5 +60,12 @@ describe('editEntry', () => {
     vi.mocked(prisma.joke.delete).mockRejectedValue(new Error('gone'))
 
     expect(await deleteEntry('jokes', 'j1')).toEqual({ ok: false })
+  })
+
+  it('deletes a gift', async () => {
+    const result = await deleteEntry('gifts', 'g1')
+
+    expect(result).toEqual({ ok: true })
+    expect(prisma.gift.delete).toHaveBeenCalledWith({ where: { id: 'g1' } })
   })
 })

--- a/src/app/actions/editEntry.ts
+++ b/src/app/actions/editEntry.ts
@@ -3,7 +3,7 @@
 import { prisma } from '@/lib/db'
 import { revalidatePath } from 'next/cache'
 
-export type EditableField = 'likes' | 'dislikes' | 'jokes' | 'dreams' | 'trips'
+export type EditableField = 'likes' | 'dislikes' | 'jokes' | 'dreams' | 'trips' | 'gifts'
 
 // Each model's own text column — they are not interchangeable.
 const TABLE = {
@@ -17,6 +17,8 @@ const TABLE = {
     prisma.dream.update({ where: { id }, data: { description: text } }),
   trips: (id: string, text: string) =>
     prisma.trip.update({ where: { id }, data: { destination: text } }),
+  gifts: (id: string, text: string) =>
+    prisma.gift.update({ where: { id }, data: { description: text } }),
 } as const
 
 const DELETE = {
@@ -25,6 +27,7 @@ const DELETE = {
   jokes: (id: string) => prisma.joke.delete({ where: { id } }),
   dreams: (id: string) => prisma.dream.delete({ where: { id } }),
   trips: (id: string) => prisma.trip.delete({ where: { id } }),
+  gifts: (id: string) => prisma.gift.delete({ where: { id } }),
 } as const
 
 function known(field: string): field is EditableField {

--- a/src/components/GiftHistory.tsx
+++ b/src/components/GiftHistory.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { rateGift } from '@/app/actions/rateGift'
+import { deleteEntry } from '@/app/actions/editEntry'
 import type { GiftRow } from '@/lib/portrait/load'
 
 type Gift = {
@@ -53,6 +54,15 @@ export default function GiftHistory({
           <span className="text-sm text-ink">{gift.description}</span>
           <span className="flex shrink-0 items-center gap-1.5">
             <Badge howItLanded={gift.howItLanded} />
+            {rows && (
+              <button
+                aria-label={`Delete ${gift.description}`}
+                onClick={() => deleteEntry('gifts', (gift as GiftRow).id)}
+                className="rounded-full border border-line px-2 py-0.5 text-xs text-ink-soft hover:bg-paper"
+              >
+                ✕
+              </button>
+            )}
             {rows && gift.howItLanded === null && (
               <>
                 <button

--- a/src/components/OccasionCard.test.tsx
+++ b/src/components/OccasionCard.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { addOccasion } from '@/app/actions/addOccasion'
+import OccasionCard from './OccasionCard'
+
+vi.mock('@/app/actions/addOccasion', () => ({ addOccasion: vi.fn() }))
+
+describe('OccasionCard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(addOccasion).mockResolvedValue({ ok: true })
+  })
+
+  it('lists occasions with month and day', () => {
+    render(
+      <OccasionCard
+        profileId="p1"
+        occasions={[
+          { label: 'her birthday', month: 9, day: 4 },
+          { label: 'our anniversary', month: 6, day: 12 },
+        ]}
+      />
+    )
+
+    expect(screen.getAllByTestId('occasion-row')).toHaveLength(2)
+    expect(screen.getByText('her birthday')).toBeInTheDocument()
+    expect(screen.getByText('September 4')).toBeInTheDocument()
+    expect(screen.getByText('June 12')).toBeInTheDocument()
+  })
+
+  it('empty state invites adding', () => {
+    render(<OccasionCard profileId="p1" occasions={[]} />)
+
+    expect(screen.getByText(/No occasions yet/)).toBeInTheDocument()
+  })
+
+  it('submits a new occasion', async () => {
+    render(<OccasionCard profileId="p1" occasions={[]} />)
+
+    await userEvent.selectOptions(screen.getByLabelText('Kind'), 'anniversary')
+    await userEvent.type(screen.getByLabelText('Label'), 'our anniversary')
+    await userEvent.selectOptions(screen.getByLabelText('Month'), 'June')
+    await userEvent.clear(screen.getByLabelText('Day'))
+    await userEvent.type(screen.getByLabelText('Day'), '12')
+    await userEvent.click(screen.getByRole('button', { name: 'Add occasion' }))
+
+    expect(addOccasion).toHaveBeenCalledWith('p1', 'anniversary', 'our anniversary', 6, 12)
+  })
+})

--- a/src/components/OccasionCard.tsx
+++ b/src/components/OccasionCard.tsx
@@ -1,0 +1,129 @@
+'use client'
+
+import { useState } from 'react'
+import { addOccasion } from '@/app/actions/addOccasion'
+
+export type OccasionView = { label: string; month: number; day: number }
+
+const MONTHS = [
+  'January', 'February', 'March', 'April', 'May', 'June', 'July',
+  'August', 'September', 'October', 'November', 'December',
+]
+
+const inputClass =
+  'w-full rounded-xl border border-line bg-paper px-3.5 py-2 text-sm text-ink ' +
+  'placeholder:text-ink-soft/70 focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent'
+
+export default function OccasionCard({
+  profileId,
+  occasions,
+}: {
+  profileId: string
+  occasions: OccasionView[]
+}) {
+  const [kind, setKind] = useState('birthday')
+  const [label, setLabel] = useState('')
+  const [month, setMonth] = useState(1)
+  const [day, setDay] = useState(1)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const result = await addOccasion(profileId, kind, label, month, day)
+    if (result.ok) setLabel('')
+  }
+
+  return (
+    <div>
+      {occasions.length > 0 ? (
+        <ul className="mb-5 space-y-2">
+          {occasions.map((o, i) => (
+            <li
+              key={i}
+              data-testid="occasion-row"
+              className="flex items-center justify-between gap-2 text-sm"
+            >
+              <span className="text-ink">{o.label}</span>
+              <span className="font-mono text-xs text-ink-soft">
+                {MONTHS[o.month - 1]} {o.day}
+              </span>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="mb-5 text-sm italic text-ink-soft">
+          No occasions yet — add her birthday and your anniversary.
+        </p>
+      )}
+
+      <form onSubmit={handleSubmit} className="space-y-3">
+        <div className="grid grid-cols-2 gap-3">
+          <div className="space-y-1.5">
+            <label htmlFor="occasion-kind" className="text-sm font-medium text-ink">
+              Kind
+            </label>
+            <select
+              id="occasion-kind"
+              value={kind}
+              onChange={(e) => setKind(e.target.value)}
+              className={inputClass}
+            >
+              <option value="birthday">birthday</option>
+              <option value="anniversary">anniversary</option>
+              <option value="other">other</option>
+            </select>
+          </div>
+          <div className="space-y-1.5">
+            <label htmlFor="occasion-label" className="text-sm font-medium text-ink">
+              Label
+            </label>
+            <input
+              id="occasion-label"
+              type="text"
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+              placeholder="her birthday"
+              className={inputClass}
+            />
+          </div>
+        </div>
+        <div className="grid grid-cols-2 gap-3">
+          <div className="space-y-1.5">
+            <label htmlFor="occasion-month" className="text-sm font-medium text-ink">
+              Month
+            </label>
+            <select
+              id="occasion-month"
+              value={month}
+              onChange={(e) => setMonth(Number(e.target.value))}
+              className={inputClass}
+            >
+              {MONTHS.map((m, i) => (
+                <option key={m} value={i + 1}>{m}</option>
+              ))}
+            </select>
+          </div>
+          <div className="space-y-1.5">
+            <label htmlFor="occasion-day" className="text-sm font-medium text-ink">
+              Day
+            </label>
+            <input
+              id="occasion-day"
+              type="number"
+              min={1}
+              max={31}
+              value={day}
+              onChange={(e) => setDay(Number(e.target.value))}
+              className={inputClass}
+            />
+          </div>
+        </div>
+        <button
+          type="submit"
+          className="rounded-xl bg-accent px-4 py-2 text-sm font-medium text-accent-ink transition-opacity hover:opacity-90"
+        >
+          Add occasion
+        </button>
+      </form>
+    </div>
+  )
+}

--- a/src/components/PortraitView.tsx
+++ b/src/components/PortraitView.tsx
@@ -7,6 +7,7 @@ import MoodTimeline from '@/components/MoodTimeline';
 import StudyMetrics from '@/components/StudyMetrics';
 import GiftHistory from '@/components/GiftHistory';
 import MoodForm from '@/components/MoodForm';
+import OccasionCard from '@/components/OccasionCard';
 import EntryForm from '@/components/EntryForm';
 
 interface PortraitViewProps {
@@ -110,6 +111,9 @@ export default function PortraitView({
         <div className="space-y-6 lg:col-span-2">
           <Card title="Moods, lately">
             <MoodTimeline buckets={buckets} />
+          </Card>
+          <Card title="Occasions">
+            <OccasionCard profileId={profileId} occasions={portrait.occasions} />
           </Card>
           <Card title="Add to the Portrait">
             <div className="space-y-8">


### PR DESCRIPTION
- **Occasions card**: the portrait finally shows birthdays and anniversaries (`getPortrait` always loaded them; nothing rendered them). List + add form; impossible dates rejected server-side; the daily cron picks new occasions up automatically with the 7-day lead default.
- **Gifts deletable** (and description-editable): ✕ on every ledger row.

**164 tests ✅ tsc ✅ lint ✅**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgUuHL6M6pBwuwozBPFph3