### PR TITLE
Gift row: ✕ last; extraction hears only real gifts

### DIFF
--- a/src/components/GiftHistory.tsx
+++ b/src/components/GiftHistory.tsx
@@ -54,15 +54,6 @@ export default function GiftHistory({
           <span className="text-sm text-ink">{gift.description}</span>
           <span className="flex shrink-0 items-center gap-1.5">
             <Badge howItLanded={gift.howItLanded} />
-            {rows && (
-              <button
-                aria-label={`Delete ${gift.description}`}
-                onClick={() => deleteEntry('gifts', (gift as GiftRow).id)}
-                className="rounded-full border border-line px-2 py-0.5 text-xs text-ink-soft hover:bg-paper"
-              >
-                ✕
-              </button>
-            )}
             {rows && gift.howItLanded === null && (
               <>
                 <button
@@ -80,6 +71,15 @@ export default function GiftHistory({
                   missed
                 </button>
               </>
+            )}
+            {rows && (
+              <button
+                aria-label={`Delete ${gift.description}`}
+                onClick={() => deleteEntry('gifts', (gift as GiftRow).id)}
+                className="rounded-full border border-line px-2 py-0.5 text-xs text-ink-soft hover:bg-paper"
+              >
+                ✕
+              </button>
             )}
           </span>
         </li>

--- a/src/lib/extraction/prompt.ts
+++ b/src/lib/extraction/prompt.ts
@@ -18,7 +18,7 @@ export function buildExtractionPrompt(context: ProfileContext, message: string):
   const occasions = context.occasions ?? [];
   if (occasions.length > 0) lines.push(`Already known occasions: ${occasions.map((o) => o.label).join(', ')}`);
 
-  return `Return ONLY a JSON object with these eight keys, each an array of strings: "likes", "dislikes", "jokes", "dreams", "moods", "events", "gifts", "trips" — plus an optional ninth key "occasions": an array of {"kind": "birthday" or "anniversary" or "other", "label": string, "month": 1-12, "day": 1-31}. Include an occasion ONLY when the user explicitly stated a recurring date with a month and day; never guess a date.
+  return `Return ONLY a JSON object with these eight keys, each an array of strings: "likes", "dislikes", "jokes", "dreams", "moods", "events", "gifts", "trips" — plus an optional ninth key "occasions": an array of {"kind": "birthday" or "anniversary" or "other", "label": string, "month": 1-12, "day": 1-31}. Include an occasion ONLY when the user explicitly stated a recurring date with a month and day; never guess a date. Under "gifts", include only ACTUAL gifts — given, received, or concretely planned; never the word gifts itself, gift ideas in the abstract, or trips (trips belong under "trips").
 
 Extract only facts the user EXPLICITLY stated about their partner in this message; never infer, never invent; return empty arrays when nothing qualifies; at most 3 items per key; do not repeat anything already listed.
 


### PR DESCRIPTION
- Ledger row order: outcome badge → landed/missed → **✕ last**
- Prod ledger cleared (3 junk rows: 'gifts', 'thoughtful gift ideas', a trip) and the extraction prompt tightened — meta-talk about gifts stops becoming rows; trips route to trips

Full suite ✅ tsc ✅ lint ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgUuHL6M6pBwuwozBPFph3