### PR TITLE
feat(#156): Story 1 — facet schema (hand-written)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,6 +22,8 @@ model Profile {
   name         String
   createdAt    DateTime      @default(now())
   updatedAt    DateTime      @updatedAt
+  portraitSummary  String?
+  summaryUpdatedAt DateTime?
   likes        LikesEntry[]
   dislikes     DislikesEntry[]
   jokes        Joke[]
@@ -36,6 +38,7 @@ model Profile {
   questionnaireAnswers QuestionnaireAnswer[]
   occasions    Occasion[]
   cadenceRuns  CadenceRun[]
+  facets       Facet[]
 }
 
 model LikesEntry {
@@ -44,6 +47,7 @@ model LikesEntry {
   text      String
   createdAt DateTime @default(now())
   source    String   @default("manual")
+  facetId   String?
   profile   Profile  @relation(fields: [profileId], references: [id], onDelete: Cascade)
 }
 
@@ -53,6 +57,7 @@ model DislikesEntry {
   text      String
   createdAt DateTime @default(now())
   source    String   @default("manual")
+  facetId   String?
   profile   Profile  @relation(fields: [profileId], references: [id], onDelete: Cascade)
 }
 
@@ -62,6 +67,7 @@ model Joke {
   text      String
   createdAt DateTime @default(now())
   source    String   @default("manual")
+  facetId   String?
   profile   Profile  @relation(fields: [profileId], references: [id], onDelete: Cascade)
 }
 
@@ -106,6 +112,7 @@ model Trip {
   note        String?
   createdAt   DateTime  @default(now())
   source    String   @default("manual")
+  facetId   String?
   profile     Profile   @relation(fields: [profileId], references: [id], onDelete: Cascade)
 }
 
@@ -115,6 +122,7 @@ model Dream {
   description String
   createdAt   DateTime @default(now())
   source    String   @default("manual")
+  facetId   String?
   profile     Profile  @relation(fields: [profileId], references: [id], onDelete: Cascade)
 }
 
@@ -177,6 +185,21 @@ model CadenceRun {
   profile   Profile  @relation(fields: [profileId], references: [id], onDelete: Cascade)
 
   @@unique([profileId, kind, ranOn])
+}
+
+model Facet {
+  id             String   @id @default(cuid())
+  profileId      String
+  section        String
+  label          String
+  evidenceCount  Int      @default(0)
+  firstNoted     DateTime @default(now())
+  lastReinforced DateTime @default(now())
+  status         String   @default("active")
+  createdAt      DateTime @default(now())
+  profile        Profile  @relation(fields: [profileId], references: [id], onDelete: Cascade)
+
+  @@index([profileId, section])
 }
 
 model User {

--- a/src/lib/facets/order.test.ts
+++ b/src/lib/facets/order.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import { staleIds, orderFacets, type FacetLite } from './order'
+
+describe('order', () => {
+  it('marks only long-unreinforced active facets stale', () => {
+    const today = new Date(Date.UTC(2024, 0, 10, 12, 0, 0))
+    
+    // 61 days before today: Jan 10 -> Nov 10 (approx)
+    // 60 days is 60 * 24 * 60 * 60 * 1000
+    const sixtyOneDaysAgo = new Date(today.getTime() - (61 * 86400000))
+    const fiftyNineDaysAgo = new Date(today.getTime() - (59 * 86400000))
+    const oneHundredDaysAgo = new Date(today.getTime() - (100 * 86400000))
+
+    const facets: FacetLite[] = [
+      { id: 'stale-target', label: 'A', status: 'active', evidenceCount: 1, lastReinforced: sixtyOneDaysAgo },
+      { id: 'not-stale', label: 'B', status: 'active', evidenceCount: 1, lastReinforced: fiftyNineDaysAgo },
+      { id: 'already-stale-but-not-active', label: 'C', status: 'rejected', evidenceCount: 1, lastReinforced: oneHundredDaysAgo },
+      { id: 'stale-but-not-active-status', label: 'D', status: 'other', evidenceCount: 1, lastReinforced: oneHundredDaysAgo },
+    ]
+
+    const result = staleIds(facets, today)
+    expect(result).toEqual(['stale-target'])
+  })
+
+  it('orders by evidence with stale last and rejected gone', () => {
+    const facets: FacetLite[] = [
+      { id: '1', label: 'Z', status: 'active', evidenceCount: 2, lastReinforced: new Date(0) },
+      { id: '2', label: 'A', status: 'active', evidenceCount: 5, lastReinforced: new Date(0) },
+      { id: '3', label: 'M', status: 'stale', evidenceCount: 9, lastReinforced: new Date(0) },
+      { id: '4', label: 'X', status: 'rejected', evidenceCount: 10, lastReinforced: new Date(0) },
+    ]
+
+    const result = orderFacets(facets)
+
+    // Expected order: 
+    // 1. Active (desc evidence): ID 2 (count 5), then ID 1 (count 2)
+    // 2. Stale: ID 3 (count 9)
+    // 3. Rejected: ID 4 is gone
+    expect(result.map(f => f.id)).toEqual(['2', '1', '3'])
+    expect(result.find(f => f.id === '4')).toBeUndefined()
+  })
+})

--- a/src/lib/facets/order.ts
+++ b/src/lib/facets/order.ts
@@ -1,0 +1,38 @@
+export type FacetLite = {
+  id: string;
+  label: string;
+  status: string;
+  evidenceCount: number;
+  lastReinforced: Date;
+};
+
+export function staleIds(facets: FacetLite[], today: Date): string[] {
+  const threshold = 60 * 86400000;
+  return facets
+    .filter((f) => {
+      if (f.status !== 'active') return false;
+      return today.getTime() - f.lastReinforced.getTime() > threshold;
+    })
+    .map((f) => f.id);
+}
+
+export function orderFacets(facets: FacetLite[]): FacetLite[] {
+  return facets
+    .filter((f) => f.status !== 'rejected')
+    .sort((a, b) => {
+      const getPriority = (status: string) => {
+        if (status === 'active') return 1;
+        if (status === 'stale') return 2;
+        return 3;
+      };
+
+      const pA = getPriority(a.status);
+      const pB = getPriority(b.status);
+
+      if (pA !== pB) return pA - pB;
+      if (a.evidenceCount !== b.evidenceCount) {
+        return b.evidenceCount - a.evidenceCount;
+      }
+      return a.label.localeCompare(b.label);
+    });
+}

--- a/src/lib/facets/parse.test.ts
+++ b/src/lib/facets/parse.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import { parseSynthesis } from './parse'
+
+describe('parse', () => {
+  it('parses reinforcement and creation', () => {
+    const raw = '{"assignments": [{"facetId": "f1", "observations": [0, 2]}, {"label": "japanese food", "observations": [1]}]}'
+    const count = 3
+    const result = parseSynthesis(raw, count)
+    expect(result).toEqual([
+      { facetId: 'f1', label: null, observations: [0, 2] },
+      { facetId: null, label: 'japanese food', observations: [1] }
+    ])
+  })
+
+  it('malformed input is empty', () => {
+    expect(parseSynthesis('nope', 5)).toEqual([])
+    expect(parseSynthesis('{"assignments": "x"}', 5)).toEqual([])
+  })
+
+  it('out-of-range and duplicate indices are dropped', () => {
+    // First assignment has 0 (valid) and 7 (out of range for count 3)
+    // Second assignment has 0 (duplicate of first)
+    const raw = '{"assignments": [{"facetId": "f1", "observations": [0, 7]}, {"label": "f2", "observations": [0]}]}'
+    const count = 3
+    const result = parseSynthesis(raw, count)
+    
+    // The first assignment should keep [0]. 
+    // The second assignment's [0] is a duplicate, so it's dropped.
+    // Since the second assignment is now empty, it is dropped entirely.
+    expect(result).toEqual([
+      { facetId: 'f1', label: null, observations: [0] }
+    ])
+  })
+
+  it('an assignment with both ids is dropped', () => {
+    const raw = '{"assignments": [{"facetId": "f1", "label": "x", "observations": [0]}]}'
+    const count = 1
+    const result = parseSynthesis(raw, count)
+    expect(result).toEqual([])
+  })
+})

--- a/src/lib/facets/parse.ts
+++ b/src/lib/facets/parse.ts
@@ -1,0 +1,51 @@
+export type Assignment = {
+  facetId: string | null;
+  label: string | null;
+  observations: number[];
+};
+
+export function parseSynthesis(raw: string, observationCount: number): Assignment[] {
+  try {
+    const start = raw.indexOf('{');
+    const end = raw.lastIndexOf('}');
+    if (start === -1 || end === -1 || end < start) return [];
+
+    const jsonStr = raw.slice(start, end + 1);
+    const data = JSON.parse(jsonStr);
+    const inputAssignments = Array.isArray(data?.assignments) ? data.assignments : [];
+
+    const seenIndices = new Set<number>();
+    const validAssignments: Assignment[] = [];
+
+    for (const item of inputAssignments) {
+      if (validAssignments.length >= 10) break;
+
+      const fId = typeof item?.facetId === 'string' && item.facetId.trim() !== '' ? item.facetId : null;
+      const lbl = typeof item?.label === 'string' && item.label.trim() !== '' ? item.label.trim().slice(0, 60) : null;
+
+      if ((fId === null && lbl === null) || (fId !== null && lbl !== null)) continue;
+
+      const obs = Array.isArray(item?.observations) ? item.observations : [];
+      const filteredObs: number[] = [];
+
+      for (const idx of obs) {
+        if (Number.isInteger(idx) && idx >= 0 && idx < observationCount && !seenIndices.has(idx)) {
+          filteredObs.push(idx);
+          seenIndices.add(idx);
+        }
+      }
+
+      if (filteredObs.length > 0) {
+        validAssignments.push({
+          facetId: fId,
+          label: lbl,
+          observations: filteredObs,
+        });
+      }
+    }
+
+    return validAssignments;
+  } catch {
+    return [];
+  }
+}

--- a/src/lib/facets/prompt.test.ts
+++ b/src/lib/facets/prompt.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { buildSynthesisPrompt } from './prompt'
+
+describe('prompt', () => {
+  it('numbers the observations', () => {
+    const input = {
+      partnerName: 'Alex',
+      section: 'Interests',
+      facets: [],
+      observations: [
+        { index: 0, text: 'gardening' },
+        { index: 1, text: 'planting herbs' }
+      ]
+    }
+
+    const prompt = buildSynthesisPrompt(input)
+
+    expect(prompt).toContain('0: gardening')
+    expect(prompt).toContain('1: planting herbs')
+  })
+
+  it('offers existing facets by id', () => {
+    const input = {
+      partnerName: 'Alex',
+      section: 'Interests',
+      facets: [
+        { id: 'f1', label: 'order at home', status: 'active' }
+      ],
+      observations: []
+    }
+
+    const prompt = buildSynthesisPrompt(input)
+
+    expect(prompt).toContain('f1')
+    expect(prompt).toContain('order at home')
+  })
+
+  it('rejected labels are forbidden, not offered', () => {
+    const input = {
+      partnerName: 'Alex',
+      section: 'Interests',
+      facets: [
+        { id: 'f2', label: 'bad label', status: 'rejected' }
+      ],
+      observations: []
+    }
+
+    const prompt = buildSynthesisPrompt(input)
+
+    // Check that the rejected label is mentioned in the context of being forbidden
+    // We use a regex to find 'bad label' and then check if 'not' or 'never' appears within 200 chars
+    const index = prompt.indexOf('bad label')
+    expect(index).not.toBe(-1)
+
+    const contextWindow = prompt.substring(Math.max(0, index - 100), Math.min(prompt.length, index + 200))
+    expect(contextWindow).toMatch(/not|never/i)
+  })
+})

--- a/src/lib/facets/prompt.ts
+++ b/src/lib/facets/prompt.ts
@@ -1,0 +1,43 @@
+export type SynthesisInput = {
+  partnerName: string;
+  section: string;
+  facets: { id: string; label: string; status: string }[];
+  observations: { index: number; text: string }[];
+};
+
+export function buildSynthesisPrompt(input: SynthesisInput): string {
+  const { partnerName, section, facets, observations } = input;
+
+  const activeFacets = facets
+    .filter((f) => f.status !== 'rejected')
+    .map((f) => `${f.id}: ${f.label}`);
+
+  const rejectedFacets = facets
+    .filter((f) => f.status === 'rejected')
+    .map((f) => f.label);
+
+  const facetInstructions = activeFacets.length > 0
+    ? `Existing facets: ${activeFacets.join(', ')}.`
+    : '';
+
+  const rejectionWarning = rejectedFacets.length > 0
+    ? ` The following labels were rejected by the user and must NOT be recreated, under this or any similar phrasing: ${rejectedFacets.join(', ')}.`
+    : '';
+
+  const observationList = observations
+    .map((o) => `${o.index}: ${o.text}`)
+    .join('\n');
+
+  return `Task: Cluster the numbered observations about ${partnerName} into findings for the section "${section}".
+
+Instructions:
+- Assign each observation index either to an existing facet by its ID or to a NEW facet with a short canonical label (2–6 words, about the partner, no meta-language).
+- Return ONLY a JSON object of the shape: { "assignments": [{ "facetId": string | null, "label": string | null, "observations": number[] }] }.
+- To reinforce an existing facet, set "facetId" (and "label" to null).
+- To create a new one, set "label" (and "facetId" to null).
+- An observation index may appear at most once; indices not confidently placed must be OMITTED, never guessed.
+${facetInstructions}${rejectionWarning}
+
+Observations:
+${observationList}`;
+}


### PR DESCRIPTION
The #114 wall again: identical entry-model bodies defeat SEARCH-block uniqueness. Hand-applied per spec. `prisma validate` + `generate` clean, suite green.

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgUuHL6M6pBwuwozBPFph3