### PR TITLE
Epic 6 — facets: synthesis, the portrait's abstract, field notes

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,6 +22,8 @@ model Profile {
   name         String
   createdAt    DateTime      @default(now())
   updatedAt    DateTime      @updatedAt
+  portraitSummary  String?
+  summaryUpdatedAt DateTime?
   likes        LikesEntry[]
   dislikes     DislikesEntry[]
   jokes        Joke[]
@@ -36,6 +38,7 @@ model Profile {
   questionnaireAnswers QuestionnaireAnswer[]
   occasions    Occasion[]
   cadenceRuns  CadenceRun[]
+  facets       Facet[]
 }
 
 model LikesEntry {
@@ -44,6 +47,7 @@ model LikesEntry {
   text      String
   createdAt DateTime @default(now())
   source    String   @default("manual")
+  facetId   String?
   profile   Profile  @relation(fields: [profileId], references: [id], onDelete: Cascade)
 }
 
@@ -53,6 +57,7 @@ model DislikesEntry {
   text      String
   createdAt DateTime @default(now())
   source    String   @default("manual")
+  facetId   String?
   profile   Profile  @relation(fields: [profileId], references: [id], onDelete: Cascade)
 }
 
@@ -62,6 +67,7 @@ model Joke {
   text      String
   createdAt DateTime @default(now())
   source    String   @default("manual")
+  facetId   String?
   profile   Profile  @relation(fields: [profileId], references: [id], onDelete: Cascade)
 }
 
@@ -106,6 +112,7 @@ model Trip {
   note        String?
   createdAt   DateTime  @default(now())
   source    String   @default("manual")
+  facetId   String?
   profile     Profile   @relation(fields: [profileId], references: [id], onDelete: Cascade)
 }
 
@@ -115,6 +122,7 @@ model Dream {
   description String
   createdAt   DateTime @default(now())
   source    String   @default("manual")
+  facetId   String?
   profile     Profile  @relation(fields: [profileId], references: [id], onDelete: Cascade)
 }
 
@@ -177,6 +185,21 @@ model CadenceRun {
   profile   Profile  @relation(fields: [profileId], references: [id], onDelete: Cascade)
 
   @@unique([profileId, kind, ranOn])
+}
+
+model Facet {
+  id             String   @id @default(cuid())
+  profileId      String
+  section        String
+  label          String
+  evidenceCount  Int      @default(0)
+  firstNoted     DateTime @default(now())
+  lastReinforced DateTime @default(now())
+  status         String   @default("active")
+  createdAt      DateTime @default(now())
+  profile        Profile  @relation(fields: [profileId], references: [id], onDelete: Cascade)
+
+  @@index([profileId, section])
 }
 
 model User {

--- a/src/app/api/cron/route.test.ts
+++ b/src/app/api/cron/route.test.ts
@@ -3,25 +3,28 @@ import { prisma } from '@/lib/db'
 import { respond } from '@/lib/coach/respond'
 import { sendMessage } from '@/lib/telegram/send'
 import { GET } from './route'
+import { synthesizeSection } from '@/lib/facets/synthesize'
+import { composePortraitSummary } from '@/lib/facets/summary'
 
 vi.mock('@/lib/db', () => ({
   prisma: {
     telegramChat: { findMany: vi.fn() },
     occasion: { findMany: vi.fn() },
     cadenceRun: { findFirst: vi.fn(), create: vi.fn() },
+    facet: { findMany: vi.fn(), updateMany: vi.fn() },
   },
 }))
 vi.mock('@/lib/coach/respond', () => ({ respond: vi.fn() }))
 vi.mock('@/lib/telegram/send', () => ({ sendMessage: vi.fn() }))
-// @/lib/cadence/due and @/lib/cadence/occasions are NOT mocked: they are pure
-// local modules, and mocking them would assert against our own mock.
+vi.mock('@/lib/facets/synthesize', () => ({ synthesizeSection: vi.fn() }))
+vi.mock('@/lib/facets/summary', () => ({ composePortraitSummary: vi.fn() }))
 
 function request(auth?: string): Request {
   return new Request('http://localhost/api/cron',
     auth ? { headers: { authorization: auth } } : undefined)
 }
 
-describe('GET /api/cron', () => {
+describe('route', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     process.env.CRON_SECRET = 'cronsecret'
@@ -32,6 +35,10 @@ describe('GET /api/cron', () => {
     vi.mocked(prisma.cadenceRun.findFirst).mockResolvedValue(null)
     vi.mocked(prisma.cadenceRun.create).mockResolvedValue({} as never)
     vi.mocked(respond).mockResolvedValue('good morning')
+    vi.mocked(prisma.facet.findMany).mockResolvedValue([] as never)
+    vi.mocked(prisma.facet.updateMany).mockResolvedValue({ count: 0 } as never)
+    vi.mocked(synthesizeSection).mockResolvedValue(1)
+    vi.mocked(composePortraitSummary).mockResolvedValue(null)
   })
 
   it('rejects a request without the cron secret', async () => {
@@ -71,5 +78,60 @@ describe('GET /api/cron', () => {
     const body = await res.json()
     expect(typeof body.sent).toBe('number')
     expect(body.sent).toBeGreaterThan(0)
+  })
+
+  it('weekly runs synthesis for the five sections', async () => {
+    // Sunday, Aug 23, 2026
+    const sunday = new Date(Date.UTC(2026, 7, 23, 13, 0, 0))
+    vi.setSystemTime(sunday)
+
+    // We need to ensure dueCadences returns 'weekly'
+    // Since we don't mock dueCadences, we rely on the real implementation
+    // which for a Sunday will include 'weekly'.
+
+    vi.mocked(prisma.facet.findMany).mockResolvedValue([
+      { id: 'f1', profileId: 'p1', section: 'likes', label: 'x', status: 'active', evidenceCount: 1, lastReinforced: new Date() } as any
+    ] as any)
+
+    const res = await GET(request('Bearer cronsecret'))
+    const body = await res.json()
+
+    const sections = ['likes', 'dislikes', 'jokes', 'dreams', 'trips']
+    for (const section of sections) {
+      expect(synthesizeSection).toHaveBeenCalledWith('p1', section)
+    }
+    expect(composePortraitSummary).toHaveBeenCalledWith('p1')
+    expect(body.synthesized).toBeGreaterThan(0)
+
+    vi.useRealTimers()
+  })
+
+  it('a plain weekday synthesizes nothing', async () => {
+    // Monday, Aug 24, 2026
+    const monday = new Date(Date.UTC(2026, 7, 24, 13, 0, 0))
+    vi.setSystemTime(monday)
+
+    const res = await GET(request('Bearer cronsecret'))
+    const body = await res.json()
+
+    expect(synthesizeSection).not.toHaveBeenCalled()
+    expect(body.synthesized).toBe(0)
+
+    vi.useRealTimers()
+  })
+
+  it('synthesis failure does not break the check-in', async () => {
+    // Sunday, Aug 23, 2026
+    const sunday = new Date(Date.UTC(2026, 7, 23, 13, 0, 0))
+    vi.setSystemTime(sunday)
+
+    vi.mocked(synthesizeSection).mockRejectedValue(new Error('Synthesis failed'))
+
+    const res = await GET(request('Bearer cronsecret'))
+
+    expect(res.status).toBe(200)
+    expect(sendMessage).toHaveBeenCalled()
+
+    vi.useRealTimers()
   })
 })

--- a/src/app/api/cron/route.ts
+++ b/src/app/api/cron/route.ts
@@ -3,6 +3,9 @@ import { respond } from '@/lib/coach/respond'
 import { sendMessage } from '@/lib/telegram/send'
 import { dueCadences, type CadenceKind } from '@/lib/cadence/due'
 import { dueOccasions } from '@/lib/cadence/occasions'
+import { synthesizeSection, type FacetSection } from '@/lib/facets/synthesize'
+import { composePortraitSummary } from '@/lib/facets/summary'
+import { staleIds } from '@/lib/facets/order'
 
 const OPENERS: Record<CadenceKind, string> = {
   daily: 'Daily check-in: how are things going today, and what did you notice?',
@@ -23,6 +26,7 @@ export async function GET(request: Request): Promise<Response> {
   const kinds = dueCadences(today)
 
   let sent = 0
+  let synthesized = 0
   const chats = await prisma.telegramChat.findMany()
   for (const chat of chats) {
     for (const kind of kinds) {
@@ -36,6 +40,31 @@ export async function GET(request: Request): Promise<Response> {
         data: { profileId: chat.profileId, kind, ranOn },
       })
       sent += 1
+
+      if (kind === 'weekly') {
+        try {
+          const sections: FacetSection[] = ['likes', 'dislikes', 'jokes', 'dreams', 'trips']
+          for (const section of sections) {
+            const count = await synthesizeSection(chat.profileId, section)
+            synthesized += count
+          }
+
+          const facets = await prisma.facet.findMany({
+            where: { profileId: chat.profileId },
+          })
+          const ids = staleIds(facets, today)
+          if (ids.length > 0) {
+            await prisma.facet.updateMany({
+              where: { id: { in: ids } },
+              data: { status: 'stale' },
+            })
+          }
+
+          await composePortraitSummary(chat.profileId)
+        } catch (err) {
+          // Synthesis failure must not break the check-in
+        }
+      }
     }
 
     const occasions = await prisma.occasion.findMany({
@@ -57,5 +86,5 @@ export async function GET(request: Request): Promise<Response> {
     }
   }
 
-  return Response.json({ ok: true, sent })
+  return Response.json({ ok: true, sent, synthesized })
 }

--- a/src/components/FacetSection.test.tsx
+++ b/src/components/FacetSection.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import FacetSection from './FacetSection'
+
+vi.mock('@/app/actions/editEntry', () => ({
+  updateEntry: vi.fn(),
+  deleteEntry: vi.fn(),
+}))
+// EditableChip is a pure local component — rendered real.
+
+const FACETS = [
+  { id: 'f1', section: 'likes', label: 'order at home', status: 'active', evidenceCount: 5 },
+  { id: 'f2', section: 'likes', label: 'japanese food', status: 'active', evidenceCount: 2 },
+]
+const ROWS = [
+  { id: 'l1', text: 'cleanliness', source: 'extracted' },
+  { id: 'l2', text: 'orderliness', source: 'extracted' },
+  { id: 'l3', text: 'japanese food', source: 'manual' },
+]
+
+describe('FacetSection', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('renders weighted facets with hidden notes', () => {
+    render(<FacetSection title="Likes" field="likes" facets={FACETS} rows={ROWS} />)
+
+    expect(screen.getAllByTestId('facet-row')).toHaveLength(2)
+    expect(screen.getByText('×5')).toBeInTheDocument()
+    expect(screen.queryByText('cleanliness')).toBeNull()
+  })
+
+  it('field notes open on demand', async () => {
+    render(<FacetSection title="Likes" field="likes" facets={FACETS} rows={ROWS} />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Field notes (3)' }))
+
+    expect(screen.getByText('cleanliness')).toBeInTheDocument()
+  })
+
+  it('no facets falls back to chips', () => {
+    render(<FacetSection title="Likes" field="likes" facets={[]} rows={ROWS.slice(0, 2)} />)
+
+    expect(screen.getByText('cleanliness')).toBeInTheDocument()
+    expect(screen.getByText('orderliness')).toBeInTheDocument()
+    expect(screen.queryByTestId('facet-row')).toBeNull()
+  })
+
+  it('a stale facet says fading', () => {
+    render(
+      <FacetSection
+        title="Likes"
+        field="likes"
+        facets={[{ id: 'f3', section: 'likes', label: 'pickle ball', status: 'stale', evidenceCount: 1 }]}
+        rows={[]}
+      />
+    )
+
+    expect(screen.getByText('fading')).toBeInTheDocument()
+  })
+})

--- a/src/components/FacetSection.tsx
+++ b/src/components/FacetSection.tsx
@@ -1,0 +1,75 @@
+'use client'
+
+import { useState } from 'react'
+import EditableChip from '@/components/EditableChip'
+import type { EditableField } from '@/app/actions/editEntry'
+import type { FacetView, EntryRow } from '@/lib/portrait/load'
+
+function Chips({ field, rows }: { field: EditableField; rows: EntryRow[] }) {
+  return (
+    <ul className="flex flex-wrap gap-2">
+      {rows.map((row) => (
+        <li key={row.id}>
+          <EditableChip field={field} id={row.id} text={row.text} source={row.source} />
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+export default function FacetSection({
+  title,
+  field,
+  facets,
+  rows,
+}: {
+  title: string
+  field: EditableField
+  facets: FacetView[]
+  rows: EntryRow[]
+}) {
+  const [notesOpen, setNotesOpen] = useState(false)
+
+  return (
+    <section data-testid="portrait-section">
+      <h2 className="mb-3 font-display text-lg text-ink">{title}</h2>
+
+      {facets.length > 0 ? (
+        <>
+          <ul className="space-y-1.5">
+            {facets.map((facet) => (
+              <li
+                key={facet.id}
+                data-testid="facet-row"
+                className={`flex items-baseline gap-2 text-sm ${
+                  facet.status === 'stale' ? 'text-ink-soft' : 'text-ink'
+                }`}
+              >
+                <span>{facet.label}</span>
+                <span className="text-xs text-ink-soft">×{facet.evidenceCount}</span>
+                {facet.status === 'stale' && (
+                  <span className="text-xs italic text-ink-soft">fading</span>
+                )}
+              </li>
+            ))}
+          </ul>
+          <button
+            onClick={() => setNotesOpen((open) => !open)}
+            className="mt-3 text-xs text-ink-soft underline-offset-2 hover:underline"
+          >
+            Field notes ({rows.length})
+          </button>
+          {notesOpen && (
+            <div className="mt-3">
+              <Chips field={field} rows={rows} />
+            </div>
+          )}
+        </>
+      ) : rows.length > 0 ? (
+        <Chips field={field} rows={rows} />
+      ) : (
+        <p className="text-sm italic text-ink-soft">Nothing here yet.</p>
+      )}
+    </section>
+  )
+}

--- a/src/components/PortraitView.test.tsx
+++ b/src/components/PortraitView.test.tsx
@@ -185,4 +185,41 @@ describe('PortraitView', () => {
     expect(dates).toHaveTextContent('Birthday September 4')
     expect(dates).toHaveTextContent('Anniversary June 12')
   })
+
+  it('the abstract renders when present', () => {
+    render(
+      <PortraitView
+        portrait={{ ...portraitFixture, summary: 'She is a maker of order.' }}
+        profileId="p1"
+        coverage={{ filled: 0, total: 8, gaps: [] }}
+        daysSinceTouch={null}
+        giftStats={{ logged: 0, hits: 0, misses: 0, unrated: 0, successRate: null }}
+        buckets={[]}
+      />
+    )
+
+    expect(screen.getByTestId('portrait-summary')).toHaveTextContent(
+      'She is a maker of order.')
+  })
+
+  it('facets route to their section', () => {
+    render(
+      <PortraitView
+        portrait={{
+          ...portraitFixture,
+          facets: [
+            { id: 'f1', section: 'likes', label: 'order at home', status: 'active', evidenceCount: 4 },
+          ],
+        }}
+        profileId="p1"
+        coverage={{ filled: 0, total: 8, gaps: [] }}
+        daysSinceTouch={null}
+        giftStats={{ logged: 0, hits: 0, misses: 0, unrated: 0, successRate: null }}
+        buckets={[]}
+      />
+    )
+
+    expect(screen.getByText('order at home')).toBeInTheDocument()
+    expect(screen.getAllByTestId('facet-row')).toHaveLength(1)
+  })
 })

--- a/src/components/PortraitView.tsx
+++ b/src/components/PortraitView.tsx
@@ -2,7 +2,7 @@ import type { Portrait } from '@/lib/portrait/load';
 import type { Coverage } from '@/lib/metrics/coverage';
 import type { GiftStats } from '@/lib/metrics/gifts';
 import type { MoodBucket } from '@/lib/metrics/moodBuckets';
-import EditableSection from '@/components/EditableSection';
+import FacetSection from '@/components/FacetSection';
 import MoodTimeline from '@/components/MoodTimeline';
 import StudyMetrics from '@/components/StudyMetrics';
 import GiftHistory from '@/components/GiftHistory';
@@ -80,6 +80,14 @@ export default function PortraitView({
             )}
           </p>
         )}
+        {portrait.summary && (
+          <p
+            data-testid="portrait-summary"
+            className="mt-5 max-w-2xl font-display text-lg leading-relaxed text-ink"
+          >
+            {portrait.summary}
+          </p>
+        )}
       </header>
 
       <div className="mb-8">
@@ -94,30 +102,35 @@ export default function PortraitView({
         <div className="space-y-6 lg:col-span-3">
           <Card>
             <div className="space-y-7">
-              <EditableSection
+              <FacetSection
                 title="Likes"
                 field="likes"
                 rows={portrait.entries?.likes ?? []}
+                facets={(portrait.facets ?? []).filter((f) => f.section === 'likes')}
               />
-              <EditableSection
+              <FacetSection
                 title="Dislikes"
                 field="dislikes"
                 rows={portrait.entries?.dislikes ?? []}
+                facets={(portrait.facets ?? []).filter((f) => f.section === 'dislikes')}
               />
-              <EditableSection
+              <FacetSection
                 title="Jokes"
                 field="jokes"
                 rows={portrait.entries?.jokes ?? []}
+                facets={(portrait.facets ?? []).filter((f) => f.section === 'jokes')}
               />
-              <EditableSection
+              <FacetSection
                 title="Dreams & Wishes"
                 field="dreams"
                 rows={portrait.entries?.dreams ?? []}
+                facets={(portrait.facets ?? []).filter((f) => f.section === 'dreams')}
               />
-              <EditableSection
+              <FacetSection
                 title="Trips"
                 field="trips"
                 rows={portrait.entries?.trips ?? []}
+                facets={(portrait.facets ?? []).filter((f) => f.section === 'trips')}
               />
             </div>
           </Card>

--- a/src/lib/facets/order.test.ts
+++ b/src/lib/facets/order.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import { staleIds, orderFacets, type FacetLite } from './order'
+
+describe('order', () => {
+  it('marks only long-unreinforced active facets stale', () => {
+    const today = new Date(Date.UTC(2024, 0, 10, 12, 0, 0))
+    
+    // 61 days before today: Jan 10 -> Nov 10 (approx)
+    // 60 days is 60 * 24 * 60 * 60 * 1000
+    const sixtyOneDaysAgo = new Date(today.getTime() - (61 * 86400000))
+    const fiftyNineDaysAgo = new Date(today.getTime() - (59 * 86400000))
+    const oneHundredDaysAgo = new Date(today.getTime() - (100 * 86400000))
+
+    const facets: FacetLite[] = [
+      { id: 'stale-target', label: 'A', status: 'active', evidenceCount: 1, lastReinforced: sixtyOneDaysAgo },
+      { id: 'not-stale', label: 'B', status: 'active', evidenceCount: 1, lastReinforced: fiftyNineDaysAgo },
+      { id: 'already-stale-but-not-active', label: 'C', status: 'rejected', evidenceCount: 1, lastReinforced: oneHundredDaysAgo },
+      { id: 'stale-but-not-active-status', label: 'D', status: 'other', evidenceCount: 1, lastReinforced: oneHundredDaysAgo },
+    ]
+
+    const result = staleIds(facets, today)
+    expect(result).toEqual(['stale-target'])
+  })
+
+  it('orders by evidence with stale last and rejected gone', () => {
+    const facets: FacetLite[] = [
+      { id: '1', label: 'Z', status: 'active', evidenceCount: 2, lastReinforced: new Date(0) },
+      { id: '2', label: 'A', status: 'active', evidenceCount: 5, lastReinforced: new Date(0) },
+      { id: '3', label: 'M', status: 'stale', evidenceCount: 9, lastReinforced: new Date(0) },
+      { id: '4', label: 'X', status: 'rejected', evidenceCount: 10, lastReinforced: new Date(0) },
+    ]
+
+    const result = orderFacets(facets)
+
+    // Expected order: 
+    // 1. Active (desc evidence): ID 2 (count 5), then ID 1 (count 2)
+    // 2. Stale: ID 3 (count 9)
+    // 3. Rejected: ID 4 is gone
+    expect(result.map(f => f.id)).toEqual(['2', '1', '3'])
+    expect(result.find(f => f.id === '4')).toBeUndefined()
+  })
+})

--- a/src/lib/facets/order.ts
+++ b/src/lib/facets/order.ts
@@ -1,0 +1,38 @@
+export type FacetLite = {
+  id: string;
+  label: string;
+  status: string;
+  evidenceCount: number;
+  lastReinforced: Date;
+};
+
+export function staleIds(facets: FacetLite[], today: Date): string[] {
+  const threshold = 60 * 86400000;
+  return facets
+    .filter((f) => {
+      if (f.status !== 'active') return false;
+      return today.getTime() - f.lastReinforced.getTime() > threshold;
+    })
+    .map((f) => f.id);
+}
+
+export function orderFacets(facets: FacetLite[]): FacetLite[] {
+  return facets
+    .filter((f) => f.status !== 'rejected')
+    .sort((a, b) => {
+      const getPriority = (status: string) => {
+        if (status === 'active') return 1;
+        if (status === 'stale') return 2;
+        return 3;
+      };
+
+      const pA = getPriority(a.status);
+      const pB = getPriority(b.status);
+
+      if (pA !== pB) return pA - pB;
+      if (a.evidenceCount !== b.evidenceCount) {
+        return b.evidenceCount - a.evidenceCount;
+      }
+      return a.label.localeCompare(b.label);
+    });
+}

--- a/src/lib/facets/parse.test.ts
+++ b/src/lib/facets/parse.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import { parseSynthesis } from './parse'
+
+describe('parse', () => {
+  it('parses reinforcement and creation', () => {
+    const raw = '{"assignments": [{"facetId": "f1", "observations": [0, 2]}, {"label": "japanese food", "observations": [1]}]}'
+    const count = 3
+    const result = parseSynthesis(raw, count)
+    expect(result).toEqual([
+      { facetId: 'f1', label: null, observations: [0, 2] },
+      { facetId: null, label: 'japanese food', observations: [1] }
+    ])
+  })
+
+  it('malformed input is empty', () => {
+    expect(parseSynthesis('nope', 5)).toEqual([])
+    expect(parseSynthesis('{"assignments": "x"}', 5)).toEqual([])
+  })
+
+  it('out-of-range and duplicate indices are dropped', () => {
+    // First assignment has 0 (valid) and 7 (out of range for count 3)
+    // Second assignment has 0 (duplicate of first)
+    const raw = '{"assignments": [{"facetId": "f1", "observations": [0, 7]}, {"label": "f2", "observations": [0]}]}'
+    const count = 3
+    const result = parseSynthesis(raw, count)
+    
+    // The first assignment should keep [0]. 
+    // The second assignment's [0] is a duplicate, so it's dropped.
+    // Since the second assignment is now empty, it is dropped entirely.
+    expect(result).toEqual([
+      { facetId: 'f1', label: null, observations: [0] }
+    ])
+  })
+
+  it('an assignment with both ids is dropped', () => {
+    const raw = '{"assignments": [{"facetId": "f1", "label": "x", "observations": [0]}]}'
+    const count = 1
+    const result = parseSynthesis(raw, count)
+    expect(result).toEqual([])
+  })
+})

--- a/src/lib/facets/parse.ts
+++ b/src/lib/facets/parse.ts
@@ -1,0 +1,51 @@
+export type Assignment = {
+  facetId: string | null;
+  label: string | null;
+  observations: number[];
+};
+
+export function parseSynthesis(raw: string, observationCount: number): Assignment[] {
+  try {
+    const start = raw.indexOf('{');
+    const end = raw.lastIndexOf('}');
+    if (start === -1 || end === -1 || end < start) return [];
+
+    const jsonStr = raw.slice(start, end + 1);
+    const data = JSON.parse(jsonStr);
+    const inputAssignments = Array.isArray(data?.assignments) ? data.assignments : [];
+
+    const seenIndices = new Set<number>();
+    const validAssignments: Assignment[] = [];
+
+    for (const item of inputAssignments) {
+      if (validAssignments.length >= 10) break;
+
+      const fId = typeof item?.facetId === 'string' && item.facetId.trim() !== '' ? item.facetId : null;
+      const lbl = typeof item?.label === 'string' && item.label.trim() !== '' ? item.label.trim().slice(0, 60) : null;
+
+      if ((fId === null && lbl === null) || (fId !== null && lbl !== null)) continue;
+
+      const obs = Array.isArray(item?.observations) ? item.observations : [];
+      const filteredObs: number[] = [];
+
+      for (const idx of obs) {
+        if (Number.isInteger(idx) && idx >= 0 && idx < observationCount && !seenIndices.has(idx)) {
+          filteredObs.push(idx);
+          seenIndices.add(idx);
+        }
+      }
+
+      if (filteredObs.length > 0) {
+        validAssignments.push({
+          facetId: fId,
+          label: lbl,
+          observations: filteredObs,
+        });
+      }
+    }
+
+    return validAssignments;
+  } catch {
+    return [];
+  }
+}

--- a/src/lib/facets/prompt.test.ts
+++ b/src/lib/facets/prompt.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { buildSynthesisPrompt } from './prompt'
+
+describe('prompt', () => {
+  it('numbers the observations', () => {
+    const input = {
+      partnerName: 'Alex',
+      section: 'Interests',
+      facets: [],
+      observations: [
+        { index: 0, text: 'gardening' },
+        { index: 1, text: 'planting herbs' }
+      ]
+    }
+
+    const prompt = buildSynthesisPrompt(input)
+
+    expect(prompt).toContain('0: gardening')
+    expect(prompt).toContain('1: planting herbs')
+  })
+
+  it('offers existing facets by id', () => {
+    const input = {
+      partnerName: 'Alex',
+      section: 'Interests',
+      facets: [
+        { id: 'f1', label: 'order at home', status: 'active' }
+      ],
+      observations: []
+    }
+
+    const prompt = buildSynthesisPrompt(input)
+
+    expect(prompt).toContain('f1')
+    expect(prompt).toContain('order at home')
+  })
+
+  it('rejected labels are forbidden, not offered', () => {
+    const input = {
+      partnerName: 'Alex',
+      section: 'Interests',
+      facets: [
+        { id: 'f2', label: 'bad label', status: 'rejected' }
+      ],
+      observations: []
+    }
+
+    const prompt = buildSynthesisPrompt(input)
+
+    // Check that the rejected label is mentioned in the context of being forbidden
+    // We use a regex to find 'bad label' and then check if 'not' or 'never' appears within 200 chars
+    const index = prompt.indexOf('bad label')
+    expect(index).not.toBe(-1)
+
+    const contextWindow = prompt.substring(Math.max(0, index - 100), Math.min(prompt.length, index + 200))
+    expect(contextWindow).toMatch(/not|never/i)
+  })
+})

--- a/src/lib/facets/prompt.ts
+++ b/src/lib/facets/prompt.ts
@@ -1,0 +1,43 @@
+export type SynthesisInput = {
+  partnerName: string;
+  section: string;
+  facets: { id: string; label: string; status: string }[];
+  observations: { index: number; text: string }[];
+};
+
+export function buildSynthesisPrompt(input: SynthesisInput): string {
+  const { partnerName, section, facets, observations } = input;
+
+  const activeFacets = facets
+    .filter((f) => f.status !== 'rejected')
+    .map((f) => `${f.id}: ${f.label}`);
+
+  const rejectedFacets = facets
+    .filter((f) => f.status === 'rejected')
+    .map((f) => f.label);
+
+  const facetInstructions = activeFacets.length > 0
+    ? `Existing facets: ${activeFacets.join(', ')}.`
+    : '';
+
+  const rejectionWarning = rejectedFacets.length > 0
+    ? ` The following labels were rejected by the user and must NOT be recreated, under this or any similar phrasing: ${rejectedFacets.join(', ')}.`
+    : '';
+
+  const observationList = observations
+    .map((o) => `${o.index}: ${o.text}`)
+    .join('\n');
+
+  return `Task: Cluster the numbered observations about ${partnerName} into findings for the section "${section}".
+
+Instructions:
+- Assign each observation index either to an existing facet by its ID or to a NEW facet with a short canonical label (2–6 words, about the partner, no meta-language).
+- Return ONLY a JSON object of the shape: { "assignments": [{ "facetId": string | null, "label": string | null, "observations": number[] }] }.
+- To reinforce an existing facet, set "facetId" (and "label" to null).
+- To create a new one, set "label" (and "facetId" to null).
+- An observation index may appear at most once; indices not confidently placed must be OMITTED, never guessed.
+${facetInstructions}${rejectionWarning}
+
+Observations:
+${observationList}`;
+}

--- a/src/lib/facets/summary.test.ts
+++ b/src/lib/facets/summary.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { prisma } from '@/lib/db'
+import { generate } from '@/lib/ai'
+import { composePortraitSummary } from './summary'
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    profile: { findUnique: vi.fn(), update: vi.fn() },
+    facet: { findMany: vi.fn() },
+  },
+}))
+vi.mock('@/lib/ai', () => ({ generate: vi.fn() }))
+
+const FACETS = [
+  { section: 'likes', label: 'order at home', status: 'active' },
+  { section: 'likes', label: 'japanese food', status: 'active' },
+  { section: 'dislikes', label: 'surprises', status: 'active' },
+]
+
+describe('composePortraitSummary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(prisma.profile.findUnique).mockResolvedValue(
+      { id: 'p1', name: 'Yoyo' } as never)
+    vi.mocked(prisma.profile.update).mockResolvedValue({} as never)
+  })
+
+  it('composes and stores from active facets', async () => {
+    vi.mocked(prisma.facet.findMany).mockResolvedValue(FACETS as never)
+    vi.mocked(generate).mockResolvedValue('She is a maker of order.')
+
+    await expect(composePortraitSummary('p1')).resolves.toBe(
+      'She is a maker of order.')
+
+    expect(prisma.profile.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          portraitSummary: 'She is a maker of order.',
+        }),
+      }))
+  })
+
+  it('too few facets means no call and no write', async () => {
+    vi.mocked(prisma.facet.findMany).mockResolvedValue(FACETS.slice(0, 2) as never)
+
+    await expect(composePortraitSummary('p1')).resolves.toBeNull()
+    expect(generate).not.toHaveBeenCalled()
+    expect(prisma.profile.update).not.toHaveBeenCalled()
+  })
+
+  it('a model failure writes nothing', async () => {
+    vi.mocked(prisma.facet.findMany).mockResolvedValue(FACETS as never)
+    vi.mocked(generate).mockRejectedValue(new Error('down'))
+
+    await expect(composePortraitSummary('p1')).resolves.toBeNull()
+    expect(prisma.profile.update).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/facets/summary.ts
+++ b/src/lib/facets/summary.ts
@@ -1,0 +1,35 @@
+import { prisma } from '@/lib/db'
+import { generate } from '@/lib/ai'
+
+/** Compose and store the portrait's abstract from active facets.
+ * Grounding rule: the model may only rephrase findings, never add facts.
+ * Fewer than 3 active facets → no abstract; two findings is padding. */
+export async function composePortraitSummary(
+  profileId: string
+): Promise<string | null> {
+  const profile = await prisma.profile.findUnique({ where: { id: profileId } })
+  if (!profile) return null
+
+  const facets = await prisma.facet.findMany({
+    where: { profileId, status: 'active' },
+  })
+  if (facets.length < 3) return null
+
+  const findings = facets.map((f) => `${f.section}: ${f.label}`).join('\n')
+  try {
+    const raw = await generate(
+      `These are studied findings about ${profile.name}:\n${findings}\n\n` +
+      'Write 2-3 warm sentences describing them USING ONLY these findings. ' +
+      'Never add facts, names, or dates that are not in the list. No ' +
+      'preamble, no markdown — just the sentences.')
+    const summary = raw.trim()
+    if (!summary) return null
+    await prisma.profile.update({
+      where: { id: profileId },
+      data: { portraitSummary: summary, summaryUpdatedAt: new Date() },
+    })
+    return summary
+  } catch {
+    return null
+  }
+}

--- a/src/lib/facets/synthesize.test.ts
+++ b/src/lib/facets/synthesize.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { prisma } from '@/lib/db'
+import { generate } from '@/lib/ai'
+import { synthesizeSection } from './synthesize'
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    profile: { findUnique: vi.fn() },
+    facet: { findMany: vi.fn(), create: vi.fn(), update: vi.fn() },
+    likesEntry: { findMany: vi.fn(), update: vi.fn() },
+    dislikesEntry: { findMany: vi.fn(), update: vi.fn() },
+    joke: { findMany: vi.fn(), update: vi.fn() },
+    dream: { findMany: vi.fn(), update: vi.fn() },
+    trip: { findMany: vi.fn(), update: vi.fn() },
+  },
+}))
+vi.mock('@/lib/ai', () => ({ generate: vi.fn() }))
+// prompt and parse are pure local modules — never mocked.
+
+describe('synthesizeSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(prisma.profile.findUnique).mockResolvedValue(
+      { id: 'p1', name: 'Yoyo' } as never)
+    vi.mocked(prisma.facet.findMany).mockResolvedValue([] as never)
+    vi.mocked(prisma.facet.update).mockResolvedValue({} as never)
+    vi.mocked(prisma.likesEntry.update).mockResolvedValue({} as never)
+  })
+
+  it('creates a facet and assigns its observations', async () => {
+    vi.mocked(prisma.likesEntry.findMany).mockResolvedValue([
+      { id: 'l1', text: 'cleanliness' },
+      { id: 'l2', text: 'orderliness' },
+    ] as never)
+    vi.mocked(generate).mockResolvedValue(
+      '{"assignments": [{"label": "order at home", "observations": [0, 1]}]}')
+    vi.mocked(prisma.facet.create).mockResolvedValue({ id: 'f9' } as never)
+
+    await expect(synthesizeSection('p1', 'likes')).resolves.toBe(2)
+
+    expect(prisma.facet.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ label: 'order at home', evidenceCount: 2 }),
+      }))
+    expect(prisma.likesEntry.update).toHaveBeenCalledTimes(2)
+    expect(prisma.likesEntry.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { facetId: 'f9' } }))
+  })
+
+  it('reinforces an existing facet', async () => {
+    vi.mocked(prisma.facet.findMany).mockResolvedValue(
+      [{ id: 'f1', label: 'order at home', status: 'active' }] as never)
+    vi.mocked(prisma.likesEntry.findMany).mockResolvedValue(
+      [{ id: 'l3', text: 'a tidy kitchen' }] as never)
+    vi.mocked(generate).mockResolvedValue(
+      '{"assignments": [{"facetId": "f1", "observations": [0]}]}')
+
+    await expect(synthesizeSection('p1', 'likes')).resolves.toBe(1)
+
+    expect(prisma.facet.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'f1' },
+        data: expect.objectContaining({ evidenceCount: { increment: 1 } }),
+      }))
+  })
+
+  it('an unknown facet id is skipped', async () => {
+    vi.mocked(prisma.likesEntry.findMany).mockResolvedValue(
+      [{ id: 'l1', text: 'tea' }] as never)
+    vi.mocked(generate).mockResolvedValue(
+      '{"assignments": [{"facetId": "f404", "observations": [0]}]}')
+
+    await expect(synthesizeSection('p1', 'likes')).resolves.toBe(0)
+    expect(prisma.facet.update).not.toHaveBeenCalled()
+    expect(prisma.likesEntry.update).not.toHaveBeenCalled()
+  })
+
+  it('nothing unassigned means no model call', async () => {
+    vi.mocked(prisma.likesEntry.findMany).mockResolvedValue([] as never)
+
+    await expect(synthesizeSection('p1', 'likes')).resolves.toBe(0)
+    expect(generate).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/facets/synthesize.ts
+++ b/src/lib/facets/synthesize.ts
@@ -1,0 +1,89 @@
+import { prisma } from '@/lib/db'
+import { generate } from '@/lib/ai'
+import { buildSynthesisPrompt } from '@/lib/facets/prompt'
+import { parseSynthesis } from '@/lib/facets/parse'
+
+export type FacetSection = 'likes' | 'dislikes' | 'jokes' | 'dreams' | 'trips'
+
+type Row = { id: string; [key: string]: unknown }
+
+function sectionModel(section: FacetSection) {
+  switch (section) {
+    case 'likes':
+      return { findMany: (w: object) => prisma.likesEntry.findMany(w as never), update: (a: object) => prisma.likesEntry.update(a as never), column: 'text' as const }
+    case 'dislikes':
+      return { findMany: (w: object) => prisma.dislikesEntry.findMany(w as never), update: (a: object) => prisma.dislikesEntry.update(a as never), column: 'text' as const }
+    case 'jokes':
+      return { findMany: (w: object) => prisma.joke.findMany(w as never), update: (a: object) => prisma.joke.update(a as never), column: 'text' as const }
+    case 'dreams':
+      return { findMany: (w: object) => prisma.dream.findMany(w as never), update: (a: object) => prisma.dream.update(a as never), column: 'description' as const }
+    case 'trips':
+      return { findMany: (w: object) => prisma.trip.findMany(w as never), update: (a: object) => prisma.trip.update(a as never), column: 'destination' as const }
+  }
+}
+
+/** Cluster a section's unassigned observations into facets. Returns how many
+ * observations were newly assigned. Synthesis can only ever be BEHIND —
+ * an unplaced observation stays unassigned for next week — never destructive. */
+export async function synthesizeSection(
+  profileId: string,
+  section: FacetSection
+): Promise<number> {
+  const profile = await prisma.profile.findUnique({ where: { id: profileId } })
+  if (!profile) return 0
+
+  const model = sectionModel(section)
+  const observations = (await model.findMany({
+    where: { profileId, facetId: null },
+  })) as Row[]
+  if (observations.length === 0) return 0
+
+  const facets = await prisma.facet.findMany({ where: { profileId, section } })
+  const known = new Map(facets.map((f) => [f.id, f]))
+
+  const prompt = buildSynthesisPrompt({
+    partnerName: profile.name,
+    section,
+    facets: facets.map((f) => ({ id: f.id, label: f.label, status: f.status })),
+    observations: observations.map((o, index) => ({
+      index,
+      text: String(o[model.column] ?? ''),
+    })),
+  })
+  const assignments = parseSynthesis(await generate(prompt), observations.length)
+
+  let assigned = 0
+  for (const a of assignments) {
+    const rows = a.observations.map((i) => observations[i])
+    if (rows.length === 0) continue
+
+    let facetId: string
+    if (a.facetId !== null) {
+      if (!known.has(a.facetId)) continue // hallucinated id: skip, never guess
+      facetId = a.facetId
+      await prisma.facet.update({
+        where: { id: facetId },
+        data: {
+          evidenceCount: { increment: rows.length },
+          lastReinforced: new Date(),
+        },
+      })
+    } else {
+      const created = await prisma.facet.create({
+        data: {
+          profileId,
+          section,
+          label: a.label as string,
+          evidenceCount: rows.length,
+        },
+      })
+      facetId = created.id
+    }
+
+    for (const row of rows) {
+      await model.update({ where: { id: row.id }, data: { facetId } })
+      assigned++
+    }
+  }
+  return assigned
+}

--- a/src/lib/portrait/load.test.ts
+++ b/src/lib/portrait/load.test.ts
@@ -99,3 +99,19 @@ it('entries carry ids and provenance', async () => {
     { id: 'l1', text: 'tea', source: 'extracted' })
   expect(portrait?.entries?.trips[0].text).toBe('Kyoto')
 })
+
+it('facets and summary ride along', async () => {
+  vi.mocked(prisma.profile.findUnique).mockResolvedValue({
+    name: 'Yoyo',
+    portraitSummary: 'She is a maker of order.',
+    facets: [{ id: 'f1', section: 'likes', label: 'order at home', status: 'active', evidenceCount: 4 }],
+    likes: [], dislikes: [], jokes: [], dreams: [],
+    trips: [], gifts: [], occasions: [], moods: [], events: [],
+  } as never)
+
+  const portrait = await getPortrait('p1')
+
+  expect(portrait?.summary).toBe('She is a maker of order.')
+  expect(portrait?.facets).toHaveLength(1)
+  expect(portrait?.facets?.[0].label).toBe('order at home')
+})

--- a/src/lib/portrait/load.ts
+++ b/src/lib/portrait/load.ts
@@ -19,6 +19,14 @@ export type PortraitEntries = {
   gifts: GiftRow[];
 };
 
+export type FacetView = {
+  id: string;
+  section: string;
+  label: string;
+  status: string;
+  evidenceCount: number;
+};
+
 export type Portrait = {
   name: string;
   likes: string[];
@@ -50,6 +58,8 @@ export type Portrait = {
   // Optional by design (two-phase migration): consumers and fixtures that
   // predate CRUD stay valid; the loader always fills it.
   entries?: PortraitEntries;
+  summary?: string | null;
+  facets?: FacetView[];
 };
 
 export async function getPortrait(profileId: string): Promise<Portrait | null> {
@@ -63,6 +73,7 @@ export async function getPortrait(profileId: string): Promise<Portrait | null> {
       gifts: true,
       trips: true,
       occasions: true,
+      facets: { where: { status: { not: 'rejected' } } },
       moods: {
         orderBy: { recordedAt: "asc" }
       },
@@ -84,6 +95,14 @@ export async function getPortrait(profileId: string): Promise<Portrait | null> {
   });
 
   return {
+    summary: profile.portraitSummary,
+    facets: (profile.facets ?? []).map((f) => ({
+      id: f.id,
+      section: f.section,
+      label: f.label,
+      status: f.status,
+      evidenceCount: f.evidenceCount,
+    })),
     entries: {
       likes: profile.likes.map((l) => entryRow(l, l.text)),
       dislikes: profile.dislikes.map((d) => entryRow(d, d.text)),


### PR DESCRIPTION
Lands epic 6: **10 stories, 884 insertions across 19 files.** Each gate verified individually on the assembled branch (`.env.local` aside): 187 tests / 51 files ✅ · tsc ✅ · lint ✅ · build ✅.

### What changes
- **Facets**: the weekly cron (Sunday beat) clusters each section's observations into findings — "order at home ×6" instead of four synonymous chips. Reinforced facets grow; 60 quiet days fades them; rejected labels are never recreated. Unplaced observations simply wait — synthesis can only be behind, never destructive.
- **The abstract**: 2–3 sentences composed strictly from active findings, under her dates in the header serif.
- **Field notes**: every observation one click away per section, still editable/deletable. Sections without facets render chips exactly as today.

### Provenance
5 of 10 ground by Spike (all pure modules + the cron wire at 2-token cost), 5 hand-written — the schema (the known identical-bodies wall) and the multi-contract I/O + big-view stories.

### After deploy
`prisma db push` (new Facet model + summary columns), then a one-off first synthesis so facets appear before Sunday.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgUuHL6M6pBwuwozBPFph3