### PR TITLE
feat(#180): Story 2 — The coach prompt opens with understanding

### DIFF
--- a/src/lib/coach/prompt.test.ts
+++ b/src/lib/coach/prompt.test.ts
@@ -21,7 +21,7 @@ describe('prompt', () => {
   })
 
   it('includes populated sections', () => {
-    const prompt = buildCC({ ...base, likes: ['tea', 'coffee'] }, [], 'hello')
+    const prompt = buildCoachPrompt({ ...base, likes: ['tea', 'coffee'] }, [], 'hello')
     expect(prompt).toContain('Likes:')
     expect(prompt).toContain('tea')
     expect(prompt).toContain('coffee')
@@ -39,13 +39,62 @@ describe('prompt', () => {
     const prompt = buildCoachPrompt(base, [{ role: 'user', text: 'hi' }], userMsg)
     expect(prompt.endsWith(userMsg)).toBe(true)
   })
-})
 
-/**
- * Helper to avoid repetitive spreading in tests while keeping the logic clean
- * though the prompt asks to use spread in the tests themselves, 
- * I'll use the spread pattern directly in the tests as requested.
- */
-function buildCC(ctx: ProfileContext, hist: any[], msg: string) {
-  return buildCoachPrompt(ctx, hist, msg)
-}
+  it('opens with the understanding', () => {
+    const context = {
+      ...base,
+      summary: 'She is a maker of order.'
+    }
+    const prompt = buildCoachPrompt(context, [], 'hello')
+    const expectedLine = 'What you understand about Ada: She is a maker of order.'
+    
+    expect(prompt).toContain(expectedLine)
+    
+    // Ensure it appears before any section headings like Likes:
+    const summaryIndex = prompt.indexOf(expectedLine)
+    const likesIndex = prompt.indexOf('Likes:')
+    if (likesIndex !== -1) {
+      expect(summaryIndex).toBeLessThan(likesIndex)
+    }
+  })
+
+  it('findings replace raw lists per section', () => {
+    const context = {
+      ...base,
+      likes: ['orderliness', 'cleanliness'],
+      facets: [
+        {
+          section: 'likes',
+          label: 'order at home',
+          evidenceCount: 3
+        }
+      ]
+    }
+    const prompt = buildCoachPrompt(context, [], 'hello')
+    
+    expect(prompt).toContain('order at home (×3)')
+    expect(prompt).not.toContain('orderliness')
+    expect(prompt).not.toContain('cleanliness')
+  })
+
+  it('gift outcomes are named', () => {
+    const context = {
+      ...base,
+      giftRecord: [
+        { description: 'record player', howItLanded: 'hit' },
+        { description: 'perfume set', howItLanded: 'miss' },
+        { description: 'book', howItLanded: 'unrated' }
+      ]
+    }
+    const prompt = buildCoachPrompt(context, [], 'hello')
+    
+    expect(prompt).toContain('record player')
+    expect(prompt).toContain('landed')
+    
+    expect(prompt).toContain('perfume set')
+    expect(prompt).toContain('missed')
+
+    expect(prompt).toContain('book')
+    expect(prompt).toContain('unrated')
+  })
+})

--- a/src/lib/coach/prompt.ts
+++ b/src/lib/coach/prompt.ts
@@ -7,35 +7,61 @@ export function buildCoachPrompt(
 ): string {
   const sections: string[] = [];
 
-  if (context.likes.length > 0) {
-    sections.push(`Likes: ${context.likes.join(', ')}`);
+  if (context.summary) {
+    sections.push(`What you understand about ${context.name}: ${context.summary}`);
   }
-  if (context.dislikes.length > 0) {
-    sections.push(`Dislikes: ${context.dislikes.join(', ')}`);
-  }
-  if (context.jokes.length > 0) {
-    sections.push(`Jokes: ${context.jokes.join(', ')}`);
-  }
-  if (context.dreams.length > 0) {
-    sections.push(`Dreams: ${context.dreams.join(', ')}`);
-  }
+
+  const facetMap: Record<string, string> = {
+    likes: 'Likes:',
+    dislikes: 'Dislikes:',
+    jokes: 'Jokes:',
+    dreams: 'Dreams:',
+    trips: 'Past trips:',
+  };
+
+  const handleSection = (key: 'likes' | 'dislikes' | 'jokes' | 'dreams' | 'trips', rawList: string[]) => {
+    const sectionFacets = context.facets?.filter((f) => f.section === key) || [];
+    if (sectionFacets.length > 0) {
+      const heading = facetMap[key];
+      const findings = sectionFacets
+        .map((f) => `${f.label} (×${f.evidenceCount})`)
+        .join(', ');
+      sections.push(`${heading} ${findings}`);
+    } else if (rawList.length > 0) {
+      sections.push(`${facetMap[key]} ${rawList.join(', ')}`);
+    }
+  };
+
+  handleSection('likes', context.likes);
+  handleSection('dislikes', context.dislikes);
+  handleSection('jokes', context.jokes);
+  handleSection('dreams', context.dreams);
+  handleSection('trips', context.pastTrips);
+
   if (context.recentMoods.length > 0) {
     const moods = context.recentMoods
       .map((m) => `${m.label}${m.note ? ': ' + m.note : ''}`)
       .join(', ');
     sections.push(`Recent moods: ${moods}`);
   }
+
   if (context.recentEvents.length > 0) {
     const events = context.recentEvents
       .map((e) => `${e.title}${e.note ? ': ' + e.note : ''}`)
       .join(', ');
     sections.push(`Recent events: ${events}`);
   }
-  if (context.pastGifts.length > 0) {
+
+  if (context.giftRecord && context.giftRecord.length > 0) {
+    const gifts = context.giftRecord
+      .map((g) => {
+        const outcome = g.howItLanded === 'hit' ? 'landed' : g.howItLanded === 'miss' ? 'missed' : 'unrated';
+        return `${g.description} ${outcome}`;
+      })
+      .join('\n');
+    sections.push(`Gift record:\n${gifts}`);
+  } else if (context.pastGifts.length > 0) {
     sections.push(`Past gifts: ${context.pastGifts.join(', ')}`);
-  }
-  if (context.pastTrips.length > 0) {
-    sections.push(`Past trips: ${context.pastTrips.join(', ')}`);
   }
 
   const contextString = sections.length > 0 ? sections.join('\n') : '';


### PR DESCRIPTION
## Summary

Implements story #180: Story 2 — The coach prompt opens with understanding

## Verified gates (auto-captured by dag-poc)

- `smoke` exit 0
- `typecheck` exit 0
- `lint` exit 1

## Implementation provenance

- Model: `spike-coder-v3:latest` (local Ollama)
- LLM calls: 8
- Prompt tokens: 72038
- Output tokens: 8090

Closes #180

Co-Authored-By: gemma4:26b (Spike coder) <noreply@spike.local>

## Verified gates *(auto-captured by spike-guard)*

- build: ✓ exit 0 (run at 2026-08-20T20:02:39Z)
- lint: ✓ exit 0 (run at 2026-08-20T20:02:33Z)
- test: ✓ exit 0 (run at 2026-08-20T20:02:33Z)
