### PR TITLE
Epic 7 — the coach reads the study

### DIFF
--- a/src/lib/coach/ideaAsk.test.ts
+++ b/src/lib/coach/ideaAsk.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { generate } from '@/lib/ai'
+import { detectIdeaAsk } from './ideaAsk'
+
+vi.mock('@/lib/ai', () => ({ generate: vi.fn() }))
+
+describe('detectIdeaAsk', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('detects a gift ask for her', async () => {
+    vi.mocked(generate).mockResolvedValue('gift for_her')
+
+    await expect(
+      detectIdeaAsk('what should I get her for her birthday?')
+    ).resolves.toEqual({ kind: 'gift', audience: 'for_her' })
+  })
+
+  it('NONE and garbage are null', async () => {
+    vi.mocked(generate).mockResolvedValueOnce('NONE')
+    await expect(detectIdeaAsk('she had a rough day')).resolves.toBeNull()
+
+    vi.mocked(generate).mockResolvedValueOnce('banana')
+    await expect(detectIdeaAsk('banana?')).resolves.toBeNull()
+  })
+
+  it('a missing audience defaults to for_us', async () => {
+    vi.mocked(generate).mockResolvedValue('date')
+
+    await expect(detectIdeaAsk('any date ideas?')).resolves.toEqual({
+      kind: 'date',
+      audience: 'for_us',
+    })
+  })
+
+  it('a model failure is null', async () => {
+    vi.mocked(generate).mockRejectedValue(new Error('down'))
+
+    await expect(detectIdeaAsk('gift ideas?')).resolves.toBeNull()
+  })
+})

--- a/src/lib/coach/ideaAsk.ts
+++ b/src/lib/coach/ideaAsk.ts
@@ -1,0 +1,32 @@
+import { generate } from '@/lib/ai'
+
+export type IdeaAsk = {
+  kind: 'date' | 'gift' | 'trip'
+  audience: 'for_her' | 'for_us' | 'for_family'
+}
+
+const KINDS = new Set(['date', 'gift', 'trip'])
+const AUDIENCES = new Set(['for_her', 'for_us', 'for_family'])
+
+/** Is this message asking for a concrete idea? null on anything unclear —
+ * detection failing must never break the conversation. */
+export async function detectIdeaAsk(message: string): Promise<IdeaAsk | null> {
+  try {
+    const raw = await generate(
+      'Is the following message a request for a concrete date, gift, or ' +
+      'trip idea for the sender\'s partner? Reply NONE if not. Otherwise ' +
+      'reply exactly two words: the kind (date, gift, or trip) and the ' +
+      'audience (for_her when it is for the partner alone, for_us for the ' +
+      'couple, for_family for the whole family; use for_us when unclear).' +
+      `\n\nMessage: "${message}"`)
+    const words = raw.trim().toLowerCase().split(/\s+/)
+    if (!words[0] || words[0] === 'none' || !KINDS.has(words[0])) return null
+    const audience = words[1] && AUDIENCES.has(words[1]) ? words[1] : 'for_us'
+    return {
+      kind: words[0] as IdeaAsk['kind'],
+      audience: audience as IdeaAsk['audience'],
+    }
+  } catch {
+    return null
+  }
+}

--- a/src/lib/coach/prompt.test.ts
+++ b/src/lib/coach/prompt.test.ts
@@ -21,7 +21,7 @@ describe('prompt', () => {
   })
 
   it('includes populated sections', () => {
-    const prompt = buildCC({ ...base, likes: ['tea', 'coffee'] }, [], 'hello')
+    const prompt = buildCoachPrompt({ ...base, likes: ['tea', 'coffee'] }, [], 'hello')
     expect(prompt).toContain('Likes:')
     expect(prompt).toContain('tea')
     expect(prompt).toContain('coffee')
@@ -39,13 +39,62 @@ describe('prompt', () => {
     const prompt = buildCoachPrompt(base, [{ role: 'user', text: 'hi' }], userMsg)
     expect(prompt.endsWith(userMsg)).toBe(true)
   })
-})
 
-/**
- * Helper to avoid repetitive spreading in tests while keeping the logic clean
- * though the prompt asks to use spread in the tests themselves, 
- * I'll use the spread pattern directly in the tests as requested.
- */
-function buildCC(ctx: ProfileContext, hist: any[], msg: string) {
-  return buildCoachPrompt(ctx, hist, msg)
-}
+  it('opens with the understanding', () => {
+    const context = {
+      ...base,
+      summary: 'She is a maker of order.'
+    }
+    const prompt = buildCoachPrompt(context, [], 'hello')
+    const expectedLine = 'What you understand about Ada: She is a maker of order.'
+    
+    expect(prompt).toContain(expectedLine)
+    
+    // Ensure it appears before any section headings like Likes:
+    const summaryIndex = prompt.indexOf(expectedLine)
+    const likesIndex = prompt.indexOf('Likes:')
+    if (likesIndex !== -1) {
+      expect(summaryIndex).toBeLessThan(likesIndex)
+    }
+  })
+
+  it('findings replace raw lists per section', () => {
+    const context = {
+      ...base,
+      likes: ['orderliness', 'cleanliness'],
+      facets: [
+        {
+          section: 'likes',
+          label: 'order at home',
+          evidenceCount: 3
+        }
+      ]
+    }
+    const prompt = buildCoachPrompt(context, [], 'hello')
+    
+    expect(prompt).toContain('order at home (×3)')
+    expect(prompt).not.toContain('orderliness')
+    expect(prompt).not.toContain('cleanliness')
+  })
+
+  it('gift outcomes are named', () => {
+    const context = {
+      ...base,
+      giftRecord: [
+        { description: 'record player', howItLanded: 'hit' },
+        { description: 'perfume set', howItLanded: 'miss' },
+        { description: 'book', howItLanded: 'unrated' }
+      ]
+    }
+    const prompt = buildCoachPrompt(context, [], 'hello')
+    
+    expect(prompt).toContain('record player')
+    expect(prompt).toContain('landed')
+    
+    expect(prompt).toContain('perfume set')
+    expect(prompt).toContain('missed')
+
+    expect(prompt).toContain('book')
+    expect(prompt).toContain('unrated')
+  })
+})

--- a/src/lib/coach/prompt.ts
+++ b/src/lib/coach/prompt.ts
@@ -7,35 +7,61 @@ export function buildCoachPrompt(
 ): string {
   const sections: string[] = [];
 
-  if (context.likes.length > 0) {
-    sections.push(`Likes: ${context.likes.join(', ')}`);
+  if (context.summary) {
+    sections.push(`What you understand about ${context.name}: ${context.summary}`);
   }
-  if (context.dislikes.length > 0) {
-    sections.push(`Dislikes: ${context.dislikes.join(', ')}`);
-  }
-  if (context.jokes.length > 0) {
-    sections.push(`Jokes: ${context.jokes.join(', ')}`);
-  }
-  if (context.dreams.length > 0) {
-    sections.push(`Dreams: ${context.dreams.join(', ')}`);
-  }
+
+  const facetMap: Record<string, string> = {
+    likes: 'Likes:',
+    dislikes: 'Dislikes:',
+    jokes: 'Jokes:',
+    dreams: 'Dreams:',
+    trips: 'Past trips:',
+  };
+
+  const handleSection = (key: 'likes' | 'dislikes' | 'jokes' | 'dreams' | 'trips', rawList: string[]) => {
+    const sectionFacets = context.facets?.filter((f) => f.section === key) || [];
+    if (sectionFacets.length > 0) {
+      const heading = facetMap[key];
+      const findings = sectionFacets
+        .map((f) => `${f.label} (×${f.evidenceCount})`)
+        .join(', ');
+      sections.push(`${heading} ${findings}`);
+    } else if (rawList.length > 0) {
+      sections.push(`${facetMap[key]} ${rawList.join(', ')}`);
+    }
+  };
+
+  handleSection('likes', context.likes);
+  handleSection('dislikes', context.dislikes);
+  handleSection('jokes', context.jokes);
+  handleSection('dreams', context.dreams);
+  handleSection('trips', context.pastTrips);
+
   if (context.recentMoods.length > 0) {
     const moods = context.recentMoods
       .map((m) => `${m.label}${m.note ? ': ' + m.note : ''}`)
       .join(', ');
     sections.push(`Recent moods: ${moods}`);
   }
+
   if (context.recentEvents.length > 0) {
     const events = context.recentEvents
       .map((e) => `${e.title}${e.note ? ': ' + e.note : ''}`)
       .join(', ');
     sections.push(`Recent events: ${events}`);
   }
-  if (context.pastGifts.length > 0) {
+
+  if (context.giftRecord && context.giftRecord.length > 0) {
+    const gifts = context.giftRecord
+      .map((g) => {
+        const outcome = g.howItLanded === 'hit' ? 'landed' : g.howItLanded === 'miss' ? 'missed' : 'unrated';
+        return `${g.description} ${outcome}`;
+      })
+      .join('\n');
+    sections.push(`Gift record:\n${gifts}`);
+  } else if (context.pastGifts.length > 0) {
     sections.push(`Past gifts: ${context.pastGifts.join(', ')}`);
-  }
-  if (context.pastTrips.length > 0) {
-    sections.push(`Past trips: ${context.pastTrips.join(', ')}`);
   }
 
   const contextString = sections.length > 0 ? sections.join('\n') : '';

--- a/src/lib/coach/respond.test.ts
+++ b/src/lib/coach/respond.test.ts
@@ -3,6 +3,8 @@ import { prisma } from '@/lib/db'
 import { generate } from '@/lib/ai'
 import { getProfileContext, type ProfileContext } from '@/lib/profile/context'
 import { extractFacts } from '@/lib/extraction/extract'
+import { detectIdeaAsk } from '@/lib/coach/ideaAsk'
+import { generateSuggestion } from '@/lib/suggestions/generate'
 import { respond } from './respond'
 
 vi.mock('@/lib/db', () => ({
@@ -16,6 +18,8 @@ vi.mock('@/lib/db', () => ({
 vi.mock('@/lib/ai', () => ({ generate: vi.fn() }))
 vi.mock('@/lib/profile/context', () => ({ getProfileContext: vi.fn() }))
 vi.mock('@/lib/extraction/extract', () => ({ extractFacts: vi.fn() }))
+vi.mock('@/lib/coach/ideaAsk', () => ({ detectIdeaAsk: vi.fn() }))
+vi.mock('@/lib/suggestions/generate', () => ({ generateSuggestion: vi.fn() }))
 
 const base: ProfileContext = {
   name: 'Ada',
@@ -37,6 +41,7 @@ describe('respond', () => {
     vi.mocked(prisma.message.create).mockResolvedValue({} as never)
     vi.mocked(generate).mockResolvedValue('a thoughtful reply')
     vi.mocked(extractFacts).mockResolvedValue(0)
+    vi.mocked(detectIdeaAsk).mockResolvedValue(null)
   })
 
   it('returns the generated reply', async () => {
@@ -103,6 +108,24 @@ describe('respond', () => {
     await respond('p1', 'hi')
 
     expect(extractFacts).not.toHaveBeenCalled()
+  })
+
+  it('an idea ask returns a tracked suggestion', async () => {
+    vi.mocked(detectIdeaAsk).mockResolvedValue({ kind: 'gift', audience: 'for_her' })
+    vi.mocked(generateSuggestion).mockResolvedValue('a pottery wheel')
+
+    await expect(respond('p1', 'gift ideas?')).resolves.toBe('a pottery wheel')
+
+    expect(generateSuggestion).toHaveBeenCalledWith('p1', 'gift', 'for_her')
+    expect(generate).not.toHaveBeenCalled()
+    expect(prisma.message.create).toHaveBeenCalledTimes(2)
+  })
+
+  it('a failed suggestion falls back to the coach', async () => {
+    vi.mocked(detectIdeaAsk).mockResolvedValue({ kind: 'date', audience: 'for_us' })
+    vi.mocked(generateSuggestion).mockResolvedValue(null)
+
+    await expect(respond('p1', 'date ideas?')).resolves.toBe('a thoughtful reply')
   })
 })
 

--- a/src/lib/coach/respond.ts
+++ b/src/lib/coach/respond.ts
@@ -2,6 +2,8 @@ import { prisma } from '@/lib/db'
 import { generate } from '@/lib/ai'
 import { getProfileContext } from '@/lib/profile/context'
 import { buildCoachPrompt } from '@/lib/coach/prompt'
+import { detectIdeaAsk } from '@/lib/coach/ideaAsk'
+import { generateSuggestion } from '@/lib/suggestions/generate'
 import { extractFacts } from '@/lib/extraction/extract'
 
 export async function respond(
@@ -11,6 +13,37 @@ export async function respond(
   const context = await getProfileContext(profileId)
   if (!context) {
     return 'I do not have a profile set up yet.'
+  }
+
+  // A concrete idea-ask routes to the tracked suggestion engine — it knows
+  // what it already proposed and never repeats. Anything unclear falls
+  // through to the coach.
+  let ask = null
+  try {
+    ask = await detectIdeaAsk(userMessage)
+  } catch {
+    ask = null
+  }
+  if (ask) {
+    try {
+      const suggestion = await generateSuggestion(profileId, ask.kind, ask.audience)
+      if (suggestion) {
+        await prisma.message.create({
+          data: { profileId, role: 'user', text: userMessage },
+        })
+        await prisma.message.create({
+          data: { profileId, role: 'assistant', text: suggestion },
+        })
+        try {
+          await extractFacts(profileId, userMessage)
+        } catch {
+          // fail-silent by design
+        }
+        return suggestion
+      }
+    } catch {
+      // fall through to the coach
+    }
   }
 
   // Newest-first from the store, chronological for the prompt.

--- a/src/lib/profile/context.test.ts
+++ b/src/lib/profile/context.test.ts
@@ -88,3 +88,20 @@ describe('context', () => {
     })
   })
 })
+
+it('the study rides along', async () => {
+  vi.mocked(db.profile.findUnique).mockResolvedValue({
+    name: 'Yoyo',
+    portraitSummary: 'She is a maker of order.',
+    facets: [{ section: 'likes', label: 'order at home', evidenceCount: 3 }],
+    likes: [], dislikes: [], jokes: [], dreams: [], trips: [],
+    gifts: [{ description: 'record player', howItLanded: 'hit' }],
+    moods: [], events: [], occasions: [],
+  } as never)
+
+  const context = await getProfileContext('p1')
+
+  expect(context?.summary).toBe('She is a maker of order.')
+  expect(context?.facets?.[0].label).toBe('order at home')
+  expect(context?.giftRecord?.[0].howItLanded).toBe('hit')
+})

--- a/src/lib/profile/context.ts
+++ b/src/lib/profile/context.ts
@@ -12,6 +12,10 @@ export type ProfileContext = {
   pastTrips: string[];
   // Optional (additive): known recurring dates, for extraction dedupe.
   occasions?: { kind: string; label: string; month: number; day: number }[];
+  // Optional (additive): the studied layer — the coach prefers findings.
+  summary?: string | null;
+  facets?: { section: string; label: string; evidenceCount: number }[];
+  giftRecord?: { description: string; howItLanded: string | null }[];
 };
 
 export async function getProfileContext(profileId: string): Promise<ProfileContext | null> {
@@ -25,6 +29,7 @@ export async function getProfileContext(profileId: string): Promise<ProfileConte
       gifts: true,
       trips: true,
       occasions: true,
+      facets: { where: { status: 'active' } },
       moods: {
         orderBy: { recordedAt: "desc" },
         take: 10,
@@ -57,5 +62,15 @@ export async function getProfileContext(profileId: string): Promise<ProfileConte
     pastGifts: profile.gifts.map((g) => g.description),
     pastTrips: profile.trips.map((t) => t.destination),
     occasions: (profile.occasions ?? []).map((o) => ({ kind: o.kind, label: o.label, month: o.month, day: o.day })),
+    summary: profile.portraitSummary ?? null,
+    facets: (profile.facets ?? []).map((f) => ({
+      section: f.section,
+      label: f.label,
+      evidenceCount: f.evidenceCount,
+    })),
+    giftRecord: (profile.gifts ?? []).map((g) => ({
+      description: g.description,
+      howItLanded: g.howItLanded,
+    })),
   };
 }


### PR DESCRIPTION
Lands epic 7: **4 stories.** Gates verified individually (`.env.local` aside): 197 tests / 52 files ✅ · tsc ✅ · lint ✅ · build exit 0 ✅.

### What changes when this deploys
- The coach opens every conversation from the composed understanding of her
- Sections with facets send **findings** (`label ×count`) instead of raw chip lists — the prompt stays constant-size no matter how many years of check-ins accrue
- The coach knows which gifts **landed** and which **missed**
- "What should I get her?" routes to the tracked suggestion engine (unwired since epic 2) — persisted, audience-tagged, never repeats itself

### Provenance
1 of 4 ground by Spike (#180, the pure prompt rework, 235s); 3 hand-written — the modify-heavy and multi-mock shapes, per the standing capability profile.

No schema change — deploy needs nothing after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgUuHL6M6pBwuwozBPFph3