### PR TITLE
feat(#200): Story 25 — dueCadences accepts optional timezone

### DIFF
--- a/src/lib/cadence/due.test.ts
+++ b/src/lib/cadence/due.test.ts
@@ -25,4 +25,17 @@ describe('due', () => {
     const date = new Date(Date.UTC(2026, 10, 1, 9, 0, 0))
     expect(dueCadences(date)).toEqual(['daily', 'weekly', 'monthly'])
   })
+
+  it('Tokyo Saturday UTC is Sunday locally fires weekly and monthly', () => {
+    // 2026-10-31T15:00:00Z is Saturday UTC.
+    // In Tokyo (UTC+9), this is 2026-11-01 00:00:00 (Sunday and 1st of month).
+    const date = new Date(Date.UTC(2026, 9, 31, 15, 0, 0))
+    expect(dueCadences(date, 'Asia/Tokyo')).toEqual(['daily', 'weekly', 'monthly'])
+  })
+
+  it('Saturday UTC without timezone does not fire weekly', () => {
+    // 2026-10-31T15:00:00Z is Saturday UTC.
+    const date = new Date(Date.UTC(2026, 9, 31, 15, 0, 0))
+    expect(dueCadences(date)).toEqual(['daily'])
+  })
 })

--- a/src/lib/cadence/due.ts
+++ b/src/lib/cadence/due.ts
@@ -1,13 +1,27 @@
+import { localDayParts } from './localDay'
+
 export type CadenceKind = 'daily' | 'weekly' | 'monthly';
 
-export function dueCadences(today: Date): CadenceKind[] {
+export function dueCadences(today: Date, timezone?: string): CadenceKind[] {
   const cadences: CadenceKind[] = ['daily'];
 
-  if (today.getUTCDay() === 0) {
+  let dayOfWeek: number;
+  let dayOfMonth: number;
+
+  if (timezone) {
+    const parts = localDayParts(today, timezone);
+    dayOfWeek = parts.dayOfWeek;
+    dayOfMonth = parts.dayOfMonth;
+  } else {
+    dayOfWeek = today.getUTCDay();
+    dayOfMonth = today.getUTCDate();
+  }
+
+  if (dayOfWeek === 0) {
     cadences.push('weekly');
   }
 
-  if (today.getUTCDate() === 1) {
+  if (dayOfMonth === 1) {
     cadences.push('monthly');
   }
 


### PR DESCRIPTION
## Summary

Implements story #200: Story 25 — dueCadences accepts optional timezone

## Verified gates (auto-captured by dag-poc)

- `typecheck` exit 0
- `lint` exit 0
- `build` exit 0

## Implementation provenance

- Model: `spike-coder-v3:latest` (local Ollama)
- LLM calls: 2
- Prompt tokens: 16109
- Output tokens: 909

Closes #200

Co-Authored-By: gemma4:26b (Spike coder) <noreply@spike.local>

## Verified gates *(auto-captured by spike-guard)*

- build: ✓ exit 0 (run at 2026-08-25T15:02:41Z)
- lint: ✓ exit 0 (run at 2026-08-25T15:02:35Z)
- test: ✓ exit 0 (run at 2026-08-25T15:02:36Z)
