### PR TITLE
feat(#196): Story 21 — saveTimezone server action

### DIFF
--- a/src/app/actions/saveTimezone.test.ts
+++ b/src/app/actions/saveTimezone.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { prisma } from '@/lib/db'
+import type { Profile } from '@prisma/client'
+import { saveTimezone } from './saveTimezone'
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    profile: {
+      create: vi.fn(),
+      createMany: vi.fn(),
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+      findFirst: vi.fn(),
+      update: vi.fn(),
+      updateMany: vi.fn(),
+      delete: vi.fn(),
+      deleteMany: vi.fn(),
+      upsert: vi.fn(),
+      count: vi.fn(),
+    },
+    likesEntry: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    dislikesEntry: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    joke: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    mood: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    event: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    gift: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    trip: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    dream: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    suggestion: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    telegramChat: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    message: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    questionnaireAnswer: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    occasion: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    cadenceRun: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    facet: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    user: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    account: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    session: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    verificationToken: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+  },
+}))
+
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+}))
+
+const makeProfile = (overrides: Partial<Profile> = {}): Profile =>
+  ({
+    id: '',
+    name: '',
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+    portraitSummary: '',
+    summaryUpdatedAt: new Date(0),
+    timezone: '',
+    ...overrides,
+  } as unknown as Profile)
+
+describe('saveTimezone', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('invalid timezone returns ok:false without calling prisma.profile.update', async () => {
+    const res = await saveTimezone('p1', 'Invalid/Timezone_Name')
+    expect(res).toEqual({ ok: false })
+    expect(prisma.profile.update).not.toHaveBeenCalled()
+  })
+
+  it('empty string returns ok:false without calling prisma.profile.update', async () => {
+    const res = await saveTimezone('p1', '')
+    expect(res).toEqual({ ok: false })
+    expect(prisma.profile.update).not.toHaveBeenCalled()
+  })
+
+  it('valid timezone calls prisma.profile.update with correct args and returns ok:true', async () => {
+    vi.mocked(prisma.profile.update).mockResolvedValue({} as any)
+    
+    const res = await saveTimezone('p1', 'America/New_York')
+    
+    expect(res).toEqual({ ok: true })
+    expect(prisma.profile.update).toHaveBeenCalledTimes(1)
+    const arg = vi.mocked(prisma.profile.update).mock.calls[0][0]
+    expect(arg.where).toEqual({ id: 'p1' })
+    expect(arg.data).toEqual({ timezone: 'America/New_York' })
+  })
+})

--- a/src/app/actions/saveTimezone.ts
+++ b/src/app/actions/saveTimezone.ts
@@ -1,0 +1,27 @@
+'use server'
+
+import { prisma } from '@/lib/db'
+import { revalidatePath } from 'next/cache'
+
+export async function saveTimezone(profileId: string, timezone: string): Promise<{ ok: boolean }> {
+  if (!timezone) {
+    return { ok: false }
+  }
+
+  try {
+    new Intl.DateTimeFormat(undefined, { timeZone: timezone })
+  } catch (err) {
+    return { ok: false }
+  }
+
+  try {
+    await prisma.profile.update({
+      where: { id: profileId },
+      data: { timezone }
+    })
+    revalidatePath('/portrait')
+    return { ok: true }
+  } catch (err) {
+    return { ok: false }
+  }
+}


### PR DESCRIPTION
## Summary

Implements story #196: Story 21 — saveTimezone server action

## Verified gates (auto-captured by dag-poc)

- `build` exit 0
- `typecheck` exit 2
- `lint` exit 1

## Implementation provenance

- Model: `spike-coder-v3:latest` (local Ollama)
- LLM calls: 3
- Prompt tokens: 26095
- Output tokens: 2646

Closes #196

Co-Authored-By: gemma4:26b (Spike coder) <noreply@spike.local>

## Verified gates *(auto-captured by spike-guard)*

- build: ✓ exit 0 (run at 2026-08-25T19:03:06Z)
- lint: ✓ exit 0 (run at 2026-08-25T19:03:01Z)
- test: ✓ exit 0 (run at 2026-08-25T19:03:02Z)
