### PR TITLE
feat: timezone UI wiring + coach local-date line (hand-written #198/#199/#203)

### DIFF
--- a/src/app/portrait/page.test.tsx
+++ b/src/app/portrait/page.test.tsx
@@ -8,6 +8,7 @@ vi.mock('@/lib/db', () => ({
   prisma: { profile: { findFirst: vi.fn() } },
 }))
 vi.mock('@/lib/portrait/load', () => ({ getPortrait: vi.fn() }))
+vi.mock('@/app/actions/saveTimezone', () => ({ saveTimezone: vi.fn() }))
 // The metrics and PortraitView are pure local modules — NOT mocked; the page
 // test proves the real wiring end to end.
 
@@ -55,5 +56,13 @@ describe('PortraitPage', () => {
     render(await PortraitPage())
 
     expect(screen.getByText('1 of 8 areas filled')).toBeInTheDocument()
+  })
+
+  it('portrait page passes timezone prop to PortraitView', async () => {
+    vi.mocked(prisma.profile.findFirst).mockResolvedValue(
+      { id: 'p1', timezone: 'America/New_York' } as never)
+    vi.mocked(getPortrait).mockResolvedValue(empty)
+    render(await PortraitPage())
+    expect(screen.getByTestId('tz-display')).toHaveTextContent('America/New_York')
   })
 })

--- a/src/app/portrait/page.tsx
+++ b/src/app/portrait/page.tsx
@@ -52,6 +52,7 @@ export default async function PortraitPage() {
       daysSinceTouch={daysSinceTouch}
       giftStats={giftStats(portrait.gifts)}
       buckets={moodBuckets(portrait.moods)}
+      timezone={profile.timezone ?? null}
     />
   )
 }

--- a/src/components/PortraitView.test.tsx
+++ b/src/components/PortraitView.test.tsx
@@ -9,6 +9,7 @@ import type { MoodBucket } from '@/lib/metrics/moodBuckets'
 
 vi.mock('@/app/actions/editEntry', () => ({ editEntry: vi.fn() }))
 vi.mock('@/app/actions/rateGift', () => ({ rateGift: vi.fn() }))
+vi.mock('@/app/actions/saveTimezone', () => ({ saveTimezone: vi.fn() }))
 
 const portraitFixture: Portrait = {
       name: 'Ada',
@@ -221,5 +222,35 @@ describe('PortraitView', () => {
 
     expect(screen.getByText('order at home')).toBeInTheDocument()
     expect(screen.getAllByTestId('facet-row')).toHaveLength(1)
+  })
+
+  it('renders tz-display when timezone prop is null', () => {
+    render(
+      <PortraitView
+        portrait={portraitFixture}
+        profileId="p1"
+        coverage={{ filled: 0, total: 8, gaps: [] }}
+        daysSinceTouch={null}
+        giftStats={{ logged: 0, hits: 0, misses: 0, unrated: 0, successRate: null }}
+        buckets={[]}
+        timezone={null}
+      />
+    )
+    expect(screen.getByTestId('tz-display')).toBeInTheDocument()
+  })
+
+  it('renders tz-display with value when timezone prop is a string', () => {
+    render(
+      <PortraitView
+        portrait={portraitFixture}
+        profileId="p1"
+        coverage={{ filled: 0, total: 8, gaps: [] }}
+        daysSinceTouch={null}
+        giftStats={{ logged: 0, hits: 0, misses: 0, unrated: 0, successRate: null }}
+        buckets={[]}
+        timezone="America/New_York"
+      />
+    )
+    expect(screen.getByTestId('tz-display')).toHaveTextContent('America/New_York')
   })
 })

--- a/src/components/PortraitView.tsx
+++ b/src/components/PortraitView.tsx
@@ -8,6 +8,7 @@ import StudyMetrics from '@/components/StudyMetrics';
 import GiftHistory from '@/components/GiftHistory';
 import MoodForm from '@/components/MoodForm';
 import EntryForm from '@/components/EntryForm';
+import TimezoneCapture from '@/components/TimezoneCapture';
 
 const MONTHS = [
   'January', 'February', 'March', 'April', 'May', 'June', 'July',
@@ -21,6 +22,7 @@ interface PortraitViewProps {
   daysSinceTouch: number | null;
   giftStats: GiftStats;
   buckets: MoodBucket[];
+  timezone?: string | null;
 }
 
 function Card({
@@ -49,6 +51,7 @@ export default function PortraitView({
   daysSinceTouch,
   giftStats,
   buckets,
+  timezone,
 }: PortraitViewProps) {
   const birthday = portrait.occasions.find((o) => o.kind === 'birthday')
   const anniversary = portrait.occasions.find((o) => o.kind === 'anniversary')
@@ -151,6 +154,8 @@ export default function PortraitView({
               <MoodForm profileId={profileId} />
               <div className="h-px bg-line" />
               <EntryForm profileId={profileId} />
+              <div className="h-px bg-line" />
+              <TimezoneCapture profileId={profileId} savedTimezone={timezone ?? null} />
             </div>
           </Card>
         </div>

--- a/src/lib/coach/prompt.test.ts
+++ b/src/lib/coach/prompt.test.ts
@@ -97,4 +97,20 @@ describe('prompt', () => {
     expect(prompt).toContain('book')
     expect(prompt).toContain('unrated')
   })
+
+  it('includes local date line when timezone is set', () => {
+    const prompt = buildCoachPrompt({ ...base, timezone: 'UTC' }, [], 'hello')
+    expect(prompt).toContain('Today is ')
+    const months = ['January','February','March','April','May','June','July',
+      'August','September','October','November','December']
+    expect(months.some((m) => prompt.includes(m))).toBe(true)
+    expect(prompt.startsWith('Today is ')).toBe(true)
+    expect(prompt.split('\n')[0]).toMatch(/^Today is [A-Z][a-z]+, [A-Z][a-z]+ \d{1,2} \(UTC\)\.$/)
+  })
+
+  it('no date line when timezone is absent', () => {
+    const prompt = buildCoachPrompt(base, [], 'hello')
+    expect(prompt).not.toContain('Today is ')
+    expect(prompt.startsWith('You are a relationship coach')).toBe(true)
+  })
 })

--- a/src/lib/coach/prompt.ts
+++ b/src/lib/coach/prompt.ts
@@ -1,4 +1,5 @@
 import type { ProfileContext } from '@/lib/profile/context';
+import { localDayParts } from '@/lib/cadence/localDay';
 
 export function buildCoachPrompt(
   context: ProfileContext,
@@ -66,7 +67,15 @@ export function buildCoachPrompt(
 
   const contextString = sections.length > 0 ? sections.join('\n') : '';
 
-  let prompt = `You are a relationship coach. Your job is to help the user understand and delight their partner, ${context.name}, using only the information provided in the profile records below.\n\n`;
+  let prompt = '';
+  if (context.timezone) {
+    const days = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+    const months = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
+    const parts = localDayParts(new Date(), context.timezone);
+    prompt += `Today is ${days[parts.dayOfWeek]}, ${months[parts.month - 1]} ${parts.dayOfMonth} (${context.timezone}).\n`;
+  }
+
+  prompt += `You are a relationship coach. Your job is to help the user understand and delight their partner, ${context.name}, using only the information provided in the profile records below.\n\n`;
 
   if (contextString) {
     prompt += `${contextString}\n\n`;


### PR DESCRIPTION
Closes the three Path-B-walled stories of the timezone feature by hand, per their ACs, red-green each:

- #198 PortraitView renders TimezoneCapture (optional `timezone` prop)
- #199 portrait page passes `profile.timezone` through
- #203 coach prompt opens with the user's local date line via `localDayParts`

Gates: tsc clean, lint 0 errors, 215/215 tests, build passes. All three grinds failed on SEARCH-block anchoring / big-test-file retyping — the Path-B canary corpus is now #55, #198, #203.

Closes #198, closes #199, closes #203.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W18cq3QmWBHN6VZowba7Zn