### PR TITLE
ci: cover PRs into dispatch/integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    branches: [main, develop]
+    branches: [main, develop, dispatch/integration]
   push:
     branches: [main, develop]
 


### PR DESCRIPTION
Story PRs (the dispatcher's entire output) target `dispatch/integration`, which wasn't in the pull_request trigger list — so #205–#212 all ran with zero checks and CI only fired after the final integration merge. One-line trigger addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W18cq3QmWBHN6VZowba7Zn