### PR TITLE
feat: dueOccasions timezone (#201) + restore hand-written #198/#199 dropped by resume reset

### DIFF
--- a/src/app/portrait/page.test.tsx
+++ b/src/app/portrait/page.test.tsx
@@ -8,6 +8,7 @@ vi.mock('@/lib/db', () => ({
   prisma: { profile: { findFirst: vi.fn() } },
 }))
 vi.mock('@/lib/portrait/load', () => ({ getPortrait: vi.fn() }))
+vi.mock('@/app/actions/saveTimezone', () => ({ saveTimezone: vi.fn() }))
 // The metrics and PortraitView are pure local modules — NOT mocked; the page
 // test proves the real wiring end to end.
 
@@ -55,5 +56,13 @@ describe('PortraitPage', () => {
     render(await PortraitPage())
 
     expect(screen.getByText('1 of 8 areas filled')).toBeInTheDocument()
+  })
+
+  it('portrait page passes timezone prop to PortraitView', async () => {
+    vi.mocked(prisma.profile.findFirst).mockResolvedValue(
+      { id: 'p1', timezone: 'America/New_York' } as never)
+    vi.mocked(getPortrait).mockResolvedValue(empty)
+    render(await PortraitPage())
+    expect(screen.getByTestId('tz-display')).toHaveTextContent('America/New_York')
   })
 })

--- a/src/app/portrait/page.tsx
+++ b/src/app/portrait/page.tsx
@@ -52,6 +52,7 @@ export default async function PortraitPage() {
       daysSinceTouch={daysSinceTouch}
       giftStats={giftStats(portrait.gifts)}
       buckets={moodBuckets(portrait.moods)}
+      timezone={profile.timezone ?? null}
     />
   )
 }

--- a/src/components/PortraitView.test.tsx
+++ b/src/components/PortraitView.test.tsx
@@ -9,6 +9,7 @@ import type { MoodBucket } from '@/lib/metrics/moodBuckets'
 
 vi.mock('@/app/actions/editEntry', () => ({ editEntry: vi.fn() }))
 vi.mock('@/app/actions/rateGift', () => ({ rateGift: vi.fn() }))
+vi.mock('@/app/actions/saveTimezone', () => ({ saveTimezone: vi.fn() }))
 
 const portraitFixture: Portrait = {
       name: 'Ada',
@@ -221,5 +222,35 @@ describe('PortraitView', () => {
 
     expect(screen.getByText('order at home')).toBeInTheDocument()
     expect(screen.getAllByTestId('facet-row')).toHaveLength(1)
+  })
+
+  it('renders tz-display when timezone prop is null', () => {
+    render(
+      <PortraitView
+        portrait={portraitFixture}
+        profileId="p1"
+        coverage={{ filled: 0, total: 8, gaps: [] }}
+        daysSinceTouch={null}
+        giftStats={{ logged: 0, hits: 0, misses: 0, unrated: 0, successRate: null }}
+        buckets={[]}
+        timezone={null}
+      />
+    )
+    expect(screen.getByTestId('tz-display')).toBeInTheDocument()
+  })
+
+  it('renders tz-display with value when timezone prop is a string', () => {
+    render(
+      <PortraitView
+        portrait={portraitFixture}
+        profileId="p1"
+        coverage={{ filled: 0, total: 8, gaps: [] }}
+        daysSinceTouch={null}
+        giftStats={{ logged: 0, hits: 0, misses: 0, unrated: 0, successRate: null }}
+        buckets={[]}
+        timezone="America/New_York"
+      />
+    )
+    expect(screen.getByTestId('tz-display')).toHaveTextContent('America/New_York')
   })
 })

--- a/src/components/PortraitView.tsx
+++ b/src/components/PortraitView.tsx
@@ -8,6 +8,7 @@ import StudyMetrics from '@/components/StudyMetrics';
 import GiftHistory from '@/components/GiftHistory';
 import MoodForm from '@/components/MoodForm';
 import EntryForm from '@/components/EntryForm';
+import TimezoneCapture from '@/components/TimezoneCapture';
 
 const MONTHS = [
   'January', 'February', 'March', 'April', 'May', 'June', 'July',
@@ -21,6 +22,7 @@ interface PortraitViewProps {
   daysSinceTouch: number | null;
   giftStats: GiftStats;
   buckets: MoodBucket[];
+  timezone?: string | null;
 }
 
 function Card({
@@ -49,6 +51,7 @@ export default function PortraitView({
   daysSinceTouch,
   giftStats,
   buckets,
+  timezone,
 }: PortraitViewProps) {
   const birthday = portrait.occasions.find((o) => o.kind === 'birthday')
   const anniversary = portrait.occasions.find((o) => o.kind === 'anniversary')
@@ -151,6 +154,8 @@ export default function PortraitView({
               <MoodForm profileId={profileId} />
               <div className="h-px bg-line" />
               <EntryForm profileId={profileId} />
+              <div className="h-px bg-line" />
+              <TimezoneCapture profileId={profileId} savedTimezone={timezone ?? null} />
             </div>
           </Card>
         </div>

--- a/src/lib/cadence/occasions.test.ts
+++ b/src/lib/cadence/occasions.test.ts
@@ -78,4 +78,13 @@ describe('occasions', () => {
     const result = dueOccasions(occasions, today)
     expect(result).toEqual([])
   })
+
+  it('NY midnight crossing: Aug 24 occasion due at 02:00 UTC in NY timezone', () => {
+    const today = new Date('2026-08-25T02:00:00Z') // 22:00 EDT Aug 24 locally
+    const occasions = [
+      { id: '1', kind: 'birthday', label: 'hers', month: 8, day: 24, leadTimeDays: 0 },
+    ]
+    const due = dueOccasions(occasions, today, 'America/New_York')
+    expect(due.map((o) => o.id)).toEqual(['1'])
+  })
 })

--- a/src/lib/cadence/occasions.ts
+++ b/src/lib/cadence/occasions.ts
@@ -1,3 +1,5 @@
+import { localDayParts } from './localDay';
+
 export type OccasionInput = {
   id: string;
   kind: string;
@@ -7,9 +9,16 @@ export type OccasionInput = {
   leadTimeDays: number;
 };
 
-export function dueOccasions(occasions: OccasionInput[], today: Date): OccasionInput[] {
+export function dueOccasions(occasions: OccasionInput[], today: Date, timezone?: string): OccasionInput[] {
   const results: OccasionInput[] = [];
-  const todayStart = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+  let todayStart: Date;
+  if (timezone) {
+    const { year, month, dayOfMonth } = localDayParts(today, timezone);
+    // UTC midnight representing the user's LOCAL calendar date.
+    todayStart = new Date(Date.UTC(year, month - 1, dayOfMonth));
+  } else {
+    todayStart = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+  }
 
   for (const occasion of occasions) {
     // 1. Start with the occurrence in the current year


### PR DESCRIPTION
Two things:

1. **#201 hand-written** — `dueOccasions` gains the optional timezone param per its AC (UTC-midnight of the user's local calendar date), red-green under TZ=UTC. Its five grind failures (each a different syntax break retyping the existing test file) put it in the Path-B canary corpus.
2. **Restores #198/#199** — the resume pass resets dispatch/integration and re-accumulates only `story/<N>-*` head-branch PRs, so the combined hand-written PR #212's content was silently dropped from the rebuilt branch. Cherry-picked back (my #203 skipped — the machine's #214 landed the same feature). Harness fix for the recognition gap coming separately.

Gates: tsc clean, 215/215 under TZ=UTC.

Closes #201, closes #198, closes #199.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W18cq3QmWBHN6VZowba7Zn