### PR TITLE
Timezone feature: the coach knows the user's local date and time (stories #193–#204)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,6 +24,7 @@ model Profile {
   updatedAt    DateTime      @updatedAt
   portraitSummary  String?
   summaryUpdatedAt DateTime?
+  timezone         String?
   likes        LikesEntry[]
   dislikes     DislikesEntry[]
   jokes        Joke[]

--- a/src/app/actions/saveTimezone.test.ts
+++ b/src/app/actions/saveTimezone.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { prisma } from '@/lib/db'
+import type { Profile } from '@prisma/client'
+import { saveTimezone } from './saveTimezone'
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    profile: {
+      create: vi.fn(),
+      createMany: vi.fn(),
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+      findFirst: vi.fn(),
+      update: vi.fn(),
+      updateMany: vi.fn(),
+      delete: vi.fn(),
+      deleteMany: vi.fn(),
+      upsert: vi.fn(),
+      count: vi.fn(),
+    },
+    likesEntry: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    dislikesEntry: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    joke: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    mood: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    event: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    gift: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    trip: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    dream: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    suggestion: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    telegramChat: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    message: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    questionnaireAnswer: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    occasion: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    cadenceRun: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    facet: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    user: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    account: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    session: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    verificationToken: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+  },
+}))
+
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+}))
+
+const makeProfile = (overrides: Partial<Profile> = {}): Profile =>
+  ({
+    id: '',
+    name: '',
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+    portraitSummary: '',
+    summaryUpdatedAt: new Date(0),
+    timezone: '',
+    ...overrides,
+  } as unknown as Profile)
+
+describe('saveTimezone', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('invalid timezone returns ok:false without calling prisma.profile.update', async () => {
+    const res = await saveTimezone('p1', 'Invalid/Timezone_Name')
+    expect(res).toEqual({ ok: false })
+    expect(prisma.profile.update).not.toHaveBeenCalled()
+  })
+
+  it('empty string returns ok:false without calling prisma.profile.update', async () => {
+    const res = await saveTimezone('p1', '')
+    expect(res).toEqual({ ok: false })
+    expect(prisma.profile.update).not.toHaveBeenCalled()
+  })
+
+  it('valid timezone calls prisma.profile.update with correct args and returns ok:true', async () => {
+    vi.mocked(prisma.profile.update).mockResolvedValue({} as any)
+    
+    const res = await saveTimezone('p1', 'America/New_York')
+    
+    expect(res).toEqual({ ok: true })
+    expect(prisma.profile.update).toHaveBeenCalledTimes(1)
+    const arg = vi.mocked(prisma.profile.update).mock.calls[0][0]
+    expect(arg.where).toEqual({ id: 'p1' })
+    expect(arg.data).toEqual({ timezone: 'America/New_York' })
+  })
+})

--- a/src/app/actions/saveTimezone.ts
+++ b/src/app/actions/saveTimezone.ts
@@ -1,0 +1,27 @@
+'use server'
+
+import { prisma } from '@/lib/db'
+import { revalidatePath } from 'next/cache'
+
+export async function saveTimezone(profileId: string, timezone: string): Promise<{ ok: boolean }> {
+  if (!timezone) {
+    return { ok: false }
+  }
+
+  try {
+    new Intl.DateTimeFormat(undefined, { timeZone: timezone })
+  } catch (err) {
+    return { ok: false }
+  }
+
+  try {
+    await prisma.profile.update({
+      where: { id: profileId },
+      data: { timezone }
+    })
+    revalidatePath('/portrait')
+    return { ok: true }
+  } catch (err) {
+    return { ok: false }
+  }
+}

--- a/src/app/api/cron/route.test.ts
+++ b/src/app/api/cron/route.test.ts
@@ -11,6 +11,7 @@ vi.mock('@/lib/db', () => ({
     telegramChat: { findMany: vi.fn() },
     occasion: { findMany: vi.fn() },
     cadenceRun: { findFirst: vi.fn(), create: vi.fn() },
+    profile: { findUnique: vi.fn() },
     facet: { findMany: vi.fn(), updateMany: vi.fn() },
   },
 }))
@@ -133,5 +134,32 @@ describe('route', () => {
     expect(sendMessage).toHaveBeenCalled()
 
     vi.useRealTimers()
+  })
+
+  it('passes timezone to dueCadences', async () => {
+    // 02:00 UTC Aug 25 = 22:00 EDT Aug 24 — an Aug-24 occasion is due ONLY if
+    // the profile timezone is threaded through (the #201 midnight crossing).
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-08-25T02:00:00Z'))
+    try {
+      vi.mocked(prisma.telegramChat.findMany).mockResolvedValue(
+        [{ chatId: 'c1', profileId: 'p1' }] as never)
+      vi.mocked(prisma.profile.findUnique).mockResolvedValue(
+        { timezone: 'America/New_York' } as never)
+      vi.mocked(prisma.cadenceRun.findFirst).mockResolvedValue({ id: 'ran' } as never)
+      vi.mocked(prisma.occasion.findMany).mockResolvedValue(
+        [{ id: 'o1', kind: 'birthday', label: 'her birthday', month: 8, day: 24, leadTimeDays: 0 }] as never)
+      vi.mocked(prisma.facet.findMany).mockResolvedValue([] as never)
+
+      const res = await GET(request('Bearer cronsecret'))
+
+      expect(res.status).toBe(200)
+      expect(prisma.profile.findUnique).toHaveBeenCalledWith(
+        { where: { id: 'p1' }, select: { timezone: true } })
+      expect(sendMessage).toHaveBeenCalledWith('c1',
+        expect.stringContaining('her birthday'))
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/src/app/api/cron/route.ts
+++ b/src/app/api/cron/route.ts
@@ -23,12 +23,15 @@ export async function GET(request: Request): Promise<Response> {
   // UTC midnight, so the once-per-day guard keys on the date, not the moment.
   const ranOn = new Date(Date.UTC(
     today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate()))
-  const kinds = dueCadences(today)
-
   let sent = 0
   let synthesized = 0
   const chats = await prisma.telegramChat.findMany()
   for (const chat of chats) {
+    const profileRow = await prisma.profile.findUnique({
+      where: { id: chat.profileId }, select: { timezone: true },
+    })
+    const timezone = profileRow?.timezone ?? undefined
+    const kinds = dueCadences(today, timezone)
     for (const kind of kinds) {
       const already = await prisma.cadenceRun.findFirst({
         where: { profileId: chat.profileId, kind, ranOn },
@@ -70,7 +73,7 @@ export async function GET(request: Request): Promise<Response> {
     const occasions = await prisma.occasion.findMany({
       where: { profileId: chat.profileId },
     })
-    for (const occasion of dueOccasions(occasions, today)) {
+    for (const occasion of dueOccasions(occasions, today, timezone)) {
       const days = Math.ceil(
         (Date.UTC(
           occasion.month - 1 < today.getUTCMonth()

--- a/src/app/portrait/page.tsx
+++ b/src/app/portrait/page.tsx
@@ -52,6 +52,7 @@ export default async function PortraitPage() {
       daysSinceTouch={daysSinceTouch}
       giftStats={giftStats(portrait.gifts)}
       buckets={moodBuckets(portrait.moods)}
+      timezone={profile.timezone ?? null}
     />
   )
 }

--- a/src/components/PortraitView.tsx
+++ b/src/components/PortraitView.tsx
@@ -8,6 +8,7 @@ import StudyMetrics from '@/components/StudyMetrics';
 import GiftHistory from '@/components/GiftHistory';
 import MoodForm from '@/components/MoodForm';
 import EntryForm from '@/components/EntryForm';
+import TimezoneCapture from '@/components/TimezoneCapture';
 
 const MONTHS = [
   'January', 'February', 'March', 'April', 'May', 'June', 'July',
@@ -21,6 +22,7 @@ interface PortraitViewProps {
   daysSinceTouch: number | null;
   giftStats: GiftStats;
   buckets: MoodBucket[];
+  timezone?: string | null;
 }
 
 function Card({
@@ -49,6 +51,7 @@ export default function PortraitView({
   daysSinceTouch,
   giftStats,
   buckets,
+  timezone,
 }: PortraitViewProps) {
   const birthday = portrait.occasions.find((o) => o.kind === 'birthday')
   const anniversary = portrait.occasions.find((o) => o.kind === 'anniversary')
@@ -151,6 +154,8 @@ export default function PortraitView({
               <MoodForm profileId={profileId} />
               <div className="h-px bg-line" />
               <EntryForm profileId={profileId} />
+              <div className="h-px bg-line" />
+              <TimezoneCapture profileId={profileId} savedTimezone={timezone ?? null} />
             </div>
           </Card>
         </div>

--- a/src/components/TimezoneCapture.test.tsx
+++ b/src/components/TimezoneCapture.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import TimezoneCapture from './TimezoneCapture'
+import { saveTimezone } from '@/app/actions/saveTimezone'
+
+vi.mock('@/app/actions/saveTimezone', () => ({
+  saveTimezone: vi.fn(),
+}))
+
+describe('TimezoneCapture', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders detecting message when savedTimezone is null', async () => {
+    render(<TimezoneCapture profileId="user-123" savedTimezone={null} />)
+    expect(screen.getByTestId('tz-display')).toHaveTextContent('Detecting timezone\u2026')
+  })
+
+  it('renders saved timezone text when savedTimezone is a string', async () => {
+    render(<TimezoneCapture profileId="user-123" savedTimezone="America/New_York" />)
+    expect(screen.getByTestId('tz-display')).toHaveTextContent('Timezone: America/New_York')
+  })
+
+  it('calls saveTimezone on mount when savedTimezone is null', async () => {
+    vi.mocked(saveTimezone).mockResolvedValue({ ok: true } as any)
+    
+    render(<TimezoneCapture profileId="user-123" savedTimezone={null} />)
+    
+    // We need to wait for the useEffect to trigger the async action
+    // Since it's an async call in useEffect, we check if it was called
+    expect(vi.mocked(saveTimezone)).toHaveBeenCalled()
+  })
+})

--- a/src/components/TimezoneCapture.tsx
+++ b/src/components/TimezoneCapture.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import { useEffect } from 'react'
+import { saveTimezone } from '@/app/actions/saveTimezone'
+
+interface TimezoneCaptureProps {
+  profileId: string
+  savedTimezone: string | null
+}
+
+export default function TimezoneCapture({ profileId, savedTimezone }: TimezoneCaptureProps) {
+  useEffect(() => {
+    const detectedTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone
+
+    if (savedTimezone === null || detectedTimezone !== savedTimezone) {
+      const performSave = async () => {
+        try {
+          await saveTimezone(profileId, detectedTimezone)
+        } catch (err) {
+          if (err instanceof Error) {
+            console.error(err.message)
+          }
+        }
+      }
+      performSave()
+    }
+  }, [profileId, savedTimezone])
+
+  return (
+    <p data-testid="tz-display">
+      {savedTimezone === null
+        ? 'Detecting timezone…'
+        : `Timezone: ${savedTimezone}`}
+    </p>
+  )
+}

--- a/src/lib/cadence/due.test.ts
+++ b/src/lib/cadence/due.test.ts
@@ -25,4 +25,17 @@ describe('due', () => {
     const date = new Date(Date.UTC(2026, 10, 1, 9, 0, 0))
     expect(dueCadences(date)).toEqual(['daily', 'weekly', 'monthly'])
   })
+
+  it('Tokyo Saturday UTC is Sunday locally fires weekly and monthly', () => {
+    // 2026-10-31T15:00:00Z is Saturday UTC.
+    // In Tokyo (UTC+9), this is 2026-11-01 00:00:00 (Sunday and 1st of month).
+    const date = new Date(Date.UTC(2026, 9, 31, 15, 0, 0))
+    expect(dueCadences(date, 'Asia/Tokyo')).toEqual(['daily', 'weekly', 'monthly'])
+  })
+
+  it('Saturday UTC without timezone does not fire weekly', () => {
+    // 2026-10-31T15:00:00Z is Saturday UTC.
+    const date = new Date(Date.UTC(2026, 9, 31, 15, 0, 0))
+    expect(dueCadences(date)).toEqual(['daily'])
+  })
 })

--- a/src/lib/cadence/due.ts
+++ b/src/lib/cadence/due.ts
@@ -1,13 +1,27 @@
+import { localDayParts } from './localDay'
+
 export type CadenceKind = 'daily' | 'weekly' | 'monthly';
 
-export function dueCadences(today: Date): CadenceKind[] {
+export function dueCadences(today: Date, timezone?: string): CadenceKind[] {
   const cadences: CadenceKind[] = ['daily'];
 
-  if (today.getUTCDay() === 0) {
+  let dayOfWeek: number;
+  let dayOfMonth: number;
+
+  if (timezone) {
+    const parts = localDayParts(today, timezone);
+    dayOfWeek = parts.dayOfWeek;
+    dayOfMonth = parts.dayOfMonth;
+  } else {
+    dayOfWeek = today.getUTCDay();
+    dayOfMonth = today.getUTCDate();
+  }
+
+  if (dayOfWeek === 0) {
     cadences.push('weekly');
   }
 
-  if (today.getUTCDate() === 1) {
+  if (dayOfMonth === 1) {
     cadences.push('monthly');
   }
 

--- a/src/lib/cadence/localDay.test.ts
+++ b/src/lib/cadence/localDay.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import { localDayParts } from './localDay'
+
+describe('localDay', () => {
+  it('UTC zone returns Tuesday Aug 25 for 2026-08-25T02Z', () => {
+    const date = new Date(Date.UTC(2026, 7, 25, 2, 0, 0)); // Month is 0-indexed, 7 = August
+    const result = localDayParts(date, 'UTC');
+
+    expect(result.year).toBe(2026);
+    expect(result.month).toBe(8);
+    expect(result.dayOfMonth).toBe(25);
+    expect(result.dayOfWeek).toBe(2); // Tuesday
+  });
+
+  it('NY zone rolls back to Monday Aug 24 for 2026-08-25T02Z', () => {
+    const date = new Date(Date.UTC(2026, 7, 25, 2, 0, 0));
+    const result = localDayParts(date, 'America/New_York');
+
+    expect(result.year).toBe(2026);
+    expect(result.month).toBe(8);
+    expect(result.dayOfMonth).toBe(24);
+    expect(result.dayOfWeek).toBe(1); // Monday
+  });
+});

--- a/src/lib/cadence/localDay.test.ts
+++ b/src/lib/cadence/localDay.test.ts
@@ -21,4 +21,26 @@ describe('localDay', () => {
     expect(result.dayOfMonth).toBe(24);
     expect(result.dayOfWeek).toBe(1); // Monday
   });
+
+  it('Tokyo forward crossing Sep 1', () => {
+    // 2026-08-31T16:00:00Z in JST (UTC+9) is 2026-09-01 01:00:00
+    const date = new Date(Date.UTC(2026, 7, 31, 16, 0, 0));
+    const result = localDayParts(date, 'Asia/Tokyo');
+
+    expect(result.year).toBe(2026);
+    expect(result.month).toBe(9);
+    expect(result.dayOfMonth).toBe(1);
+    expect(result.dayOfWeek).toBe(2); // Tuesday
+  });
+
+  it('NY Sunday Nov 1 dayOfWeek zero', () => {
+    // 2026-11-01T10:00:00Z in EST (UTC-5) is 2026-11-01 05:00:00
+    const date = new Date(Date.UTC(2026, 10, 1, 10, 0, 0));
+    const result = localDayParts(date, 'America/New_York');
+
+    expect(result.year).toBe(2026);
+    expect(result.month).toBe(11);
+    expect(result.dayOfMonth).toBe(1);
+    expect(result.dayOfWeek).toBe(0); // Sunday
+  });
 });

--- a/src/lib/cadence/localDay.ts
+++ b/src/lib/cadence/localDay.ts
@@ -1,0 +1,32 @@
+export function localDayParts(date: Date, tz: string): { year: number; month: number; dayOfMonth: number; dayOfWeek: number } {
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    timeZone: tz,
+    year: 'numeric',
+    month: 'numeric',
+    day: 'numeric',
+    weekday: 'long',
+  });
+
+  const parts = formatter.formatToParts(date);
+  const lookup: Record<string, number> = {
+    Sunday: 0,
+    Monday: 1,
+    Tuesday: 2,
+    Wednesday: 3,
+    Thursday: 4,
+    Friday: 5,
+    Saturday: 6,
+  };
+
+  const result: Record<string, string> = {};
+  for (const part of parts) {
+    result[part.type] = part.value;
+  }
+
+  return {
+    year: parseInt(result.year, 10),
+    month: parseInt(result.month, 10),
+    dayOfMonth: parseInt(result.day, 10),
+    dayOfWeek: lookup[result.weekday] ?? 0,
+  };
+}

--- a/src/lib/cadence/occasions.test.ts
+++ b/src/lib/cadence/occasions.test.ts
@@ -78,4 +78,13 @@ describe('occasions', () => {
     const result = dueOccasions(occasions, today)
     expect(result).toEqual([])
   })
+
+  it('NY midnight crossing: Aug 24 occasion due at 02:00 UTC in NY timezone', () => {
+    const today = new Date('2026-08-25T02:00:00Z') // 22:00 EDT Aug 24 locally
+    const occasions = [
+      { id: '1', kind: 'birthday', label: 'hers', month: 8, day: 24, leadTimeDays: 0 },
+    ]
+    const due = dueOccasions(occasions, today, 'America/New_York')
+    expect(due.map((o) => o.id)).toEqual(['1'])
+  })
 })

--- a/src/lib/cadence/occasions.ts
+++ b/src/lib/cadence/occasions.ts
@@ -1,3 +1,5 @@
+import { localDayParts } from './localDay';
+
 export type OccasionInput = {
   id: string;
   kind: string;
@@ -7,9 +9,16 @@ export type OccasionInput = {
   leadTimeDays: number;
 };
 
-export function dueOccasions(occasions: OccasionInput[], today: Date): OccasionInput[] {
+export function dueOccasions(occasions: OccasionInput[], today: Date, timezone?: string): OccasionInput[] {
   const results: OccasionInput[] = [];
-  const todayStart = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+  let todayStart: Date;
+  if (timezone) {
+    const { year, month, dayOfMonth } = localDayParts(today, timezone);
+    // UTC midnight representing the user's LOCAL calendar date.
+    todayStart = new Date(Date.UTC(year, month - 1, dayOfMonth));
+  } else {
+    todayStart = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+  }
 
   for (const occasion of occasions) {
     // 1. Start with the occurrence in the current year

--- a/src/lib/coach/prompt.test.ts
+++ b/src/lib/coach/prompt.test.ts
@@ -69,7 +69,7 @@ describe('prompt', () => {
           evidenceCount: 3
         }
       ]
-    }
+    } as any // Cast to any to bypass strict type check for the partial facet object
     const prompt = buildCoachPrompt(context, [], 'hello')
     
     expect(prompt).toContain('order at home (×3)')
@@ -85,7 +85,7 @@ describe('prompt', () => {
         { description: 'perfume set', howItLanded: 'miss' },
         { description: 'book', howItLanded: 'unrated' }
       ]
-    }
+    } as any
     const prompt = buildCoachPrompt(context, [], 'hello')
     
     expect(prompt).toContain('record player')
@@ -96,5 +96,16 @@ describe('prompt', () => {
 
     expect(prompt).toContain('book')
     expect(prompt).toContain('unrated')
+  })
+
+  it('includes local date line when timezone set', () => {
+    const context = { ...base, timezone: 'UTC' }
+    const prompt = buildCoachPrompt(context, [], 'hello')
+    
+    expect(prompt).toContain('Today is ')
+    
+    const months = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']
+    const hasMonth = months.some(month => prompt.includes(month))
+    expect(hasMonth).toBe(true)
   })
 })

--- a/src/lib/coach/prompt.ts
+++ b/src/lib/coach/prompt.ts
@@ -1,4 +1,5 @@
 import type { ProfileContext } from '@/lib/profile/context';
+import { localDayParts } from '@/lib/cadence/localDay';
 
 export function buildCoachPrompt(
   context: ProfileContext,
@@ -66,7 +67,18 @@ export function buildCoachPrompt(
 
   const contextString = sections.length > 0 ? sections.join('\n') : '';
 
-  let prompt = `You are a relationship coach. Your job is to help the user understand and delight their partner, ${context.name}, using only the information provided in the profile records below.\n\n`;
+  let prompt = '';
+
+  if (context.timezone) {
+    const { dayOfWeek, month, dayOfMonth } = localDayParts(new Date(), context.timezone);
+    const days = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+    const months = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
+    const dayName = days[dayOfWeek];
+    const monthName = months[month - 1];
+    prompt += `Today is ${dayName}, ${monthName} ${dayOfMonth} (${context.timezone}).\n`;
+  }
+
+  prompt += `You are a relationship coach. Your job is to help the user understand and delight their partner, ${context.name}, using only the information provided in the profile records below.\n\n`;
 
   if (contextString) {
     prompt += `${contextString}\n\n`;

--- a/src/lib/profile/context.test.ts
+++ b/src/lib/profile/context.test.ts
@@ -87,21 +87,37 @@ describe('context', () => {
       take: 10,
     })
   })
-})
 
-it('the study rides along', async () => {
-  vi.mocked(db.profile.findUnique).mockResolvedValue({
-    name: 'Yoyo',
-    portraitSummary: 'She is a maker of order.',
-    facets: [{ section: 'likes', label: 'order at home', evidenceCount: 3 }],
-    likes: [], dislikes: [], jokes: [], dreams: [], trips: [],
-    gifts: [{ description: 'record player', howItLanded: 'hit' }],
-    moods: [], events: [], occasions: [],
-  } as never)
+  it('the study rides along', async () => {
+    vi.mocked(db.profile.findUnique).mockResolvedValue({
+      name: 'Yoyo',
+      portraitSummary: 'She is a maker of order.',
+      facets: [{ section: 'likes', label: 'order at home', evidenceCount: 3 }],
+      likes: [], dislikes: [], jokes: [], dreams: [], trips: [],
+      gifts: [{ description: 'record player', howItLanded: 'hit' }],
+      moods: [], events: [], occasions: [],
+    } as any)
 
-  const context = await getProfileContext('p1')
+    const context = await getProfileContext('p1')
 
-  expect(context?.summary).toBe('She is a maker of order.')
-  expect(context?.facets?.[0].label).toBe('order at home')
-  expect(context?.giftRecord?.[0].howItLanded).toBe('hit')
+    expect(context?.summary).toBe('She is a maker of order.')
+    expect(context?.facets?.[0].label).toBe('order at home')
+    expect(context?.giftRecord?.[0].howItLanded).toBe('hit')
+  })
+
+  it('timezone rides along', async () => {
+    vi.mocked(db.profile.findUnique).mockResolvedValue({
+      id: 'p2',
+      name: 'Parisian',
+      timezone: 'Europe/Paris',
+      likes: [], dislikes: [], jokes: [], dreams: [], trips: [], gifts: [], moods: [], events: [],
+      createdAt: new Date(0),
+      updatedAt: new Date(0),
+    } as any)
+
+    const context = await getProfileContext('p2')
+
+    expect(context).not.toBeNull()
+    expect(context!.timezone).toBe('Europe/Paris')
+  })
 })

--- a/src/lib/profile/context.ts
+++ b/src/lib/profile/context.ts
@@ -10,6 +10,7 @@ export type ProfileContext = {
   recentEvents: { title: string; note: string | null }[];
   pastGifts: string[];
   pastTrips: string[];
+  timezone?: string | null;
   // Optional (additive): known recurring dates, for extraction dedupe.
   occasions?: { kind: string; label: string; month: number; day: number }[];
   // Optional (additive): the studied layer — the coach prefers findings.
@@ -41,36 +42,22 @@ export async function getProfileContext(profileId: string): Promise<ProfileConte
     },
   });
 
-  if (!profile) {
-    return null;
-  }
+  if (!profile) return null;
 
   return {
     name: profile.name,
+    timezone: profile.timezone ?? null,
     likes: profile.likes.map((l) => l.text),
     dislikes: profile.dislikes.map((d) => d.text),
     jokes: profile.jokes.map((j) => j.text),
     dreams: profile.dreams.map((dr) => dr.description),
-    recentMoods: profile.moods.map((m) => ({
-      label: m.label,
-      note: m.note,
-    })),
-    recentEvents: profile.events.map((e) => ({
-      title: e.title,
-      note: e.note,
-    })),
+    recentMoods: profile.moods.map((m) => ({ label: m.label, note: m.note })),
+    recentEvents: profile.events.map((e) => ({ title: e.title, note: e.note })),
     pastGifts: profile.gifts.map((g) => g.description),
     pastTrips: profile.trips.map((t) => t.destination),
     occasions: (profile.occasions ?? []).map((o) => ({ kind: o.kind, label: o.label, month: o.month, day: o.day })),
     summary: profile.portraitSummary ?? null,
-    facets: (profile.facets ?? []).map((f) => ({
-      section: f.section,
-      label: f.label,
-      evidenceCount: f.evidenceCount,
-    })),
-    giftRecord: (profile.gifts ?? []).map((g) => ({
-      description: g.description,
-      howItLanded: g.howItLanded,
-    })),
+    facets: (profile.facets ?? []).map((f) => ({ section: f.section, label: f.label, evidenceCount: f.evidenceCount })),
+    giftRecord: (profile.gifts ?? []).map((g) => ({ description: g.description, howItLanded: g.howItLanded })),
   };
 }


### PR DESCRIPTION
The complete local date & time feature, assembled on the dispatcher's integration branch — 12 stories:

**Machine-ground (8):** #193 schema · #194/#195 `localDayParts` · #196 `saveTimezone` action · #197 `TimezoneCapture` · #200 `dueCadences` tz · #202 ProfileContext · #203 coach prompt date line
**Hand-written at documented frontiers (4):** #198 PortraitView wiring · #199 page pass-through · #201 `dueOccasions` tz · #204 cron threading

The portrait UI silently captures the browser's IANA timezone to the profile; the coach prompt opens with the user's local date; cadence and occasion reminders key on the user's local calendar day (midnight-crossing correct).

All story PRs from #215 on ran CI; this PR runs it too. Closes all twelve story issues on merge.

Closes #193, closes #194, closes #195, closes #196, closes #197, closes #198, closes #199, closes #200, closes #201, closes #202, closes #203, closes #204.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W18cq3QmWBHN6VZowba7Zn