### PR TITLE
cd: sync database schema before deploying (fixes the timezone outage class)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -31,6 +31,17 @@ jobs:
         run: npm install -g vercel@latest
       - name: Pull Vercel project settings
         run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Sync database schema
+        # The 2026-08-26 outage: main deployed code selecting Profile.timezone
+        # while prod's DB never got the column (this repo syncs schema via
+        # db push and CD had no such step). Push the schema BEFORE deploying
+        # so code and database always move together. Uses the real
+        # DATABASE_URL from the pulled Vercel production env, not the
+        # placeholder above.
+        run: |
+          pnpm install --frozen-lockfile
+          set -a && source .vercel/.env.production.local && set +a
+          pnpm exec prisma db push --skip-generate
       - name: Build
         run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
       - name: Deploy to Vercel production


### PR DESCRIPTION
**Context: production is currently down** — #218 deployed code that selects `Profile.timezone`, but prod's Neon DB never got the column (no migrations dir; schema syncs via `db push`; CD had no sync step).

This adds a `prisma db push` step to CD, sourcing the real `DATABASE_URL` from the pulled Vercel production env, before the deploy. **Merging this to develop then main (or re-running CD via workflow_dispatch after it lands on main) applies the missing column and revives the bot** — and makes the whole outage class impossible going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W18cq3QmWBHN6VZowba7Zn