### PR TITLE
Release: CD schema-sync hotfix — revive production

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -31,6 +31,17 @@ jobs:
         run: npm install -g vercel@latest
       - name: Pull Vercel project settings
         run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Sync database schema
+        # The 2026-08-26 outage: main deployed code selecting Profile.timezone
+        # while prod's DB never got the column (this repo syncs schema via
+        # db push and CD had no such step). Push the schema BEFORE deploying
+        # so code and database always move together. Uses the real
+        # DATABASE_URL from the pulled Vercel production env, not the
+        # placeholder above.
+        run: |
+          pnpm install --frozen-lockfile
+          set -a && source .vercel/.env.production.local && set +a
+          pnpm exec prisma db push --skip-generate
       - name: Build
         run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
       - name: Deploy to Vercel production


### PR DESCRIPTION
Ships #219 to main. On merge, CD runs with the new order: **prisma db push (schema sync with real prod env) → build → deploy** — landing the missing `Profile.timezone` column and reviving the bot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W18cq3QmWBHN6VZowba7Zn