### PR TITLE
cd: drop --skip-generate from schema sync (Prisma 7 landmine)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -41,7 +41,10 @@ jobs:
         run: |
           pnpm install --frozen-lockfile
           set -a && source .vercel/.env.production.local && set +a
-          pnpm exec prisma db push --skip-generate
+          # NO --skip-generate: Prisma 7 rejects it by printing help and
+          # exiting 0 — a silent no-op that would re-plant the outage on the
+          # next Prisma upgrade (brownfield-readiness-checklist §4).
+          pnpm exec prisma db push
       - name: Build
         run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
       - name: Deploy to Vercel production


### PR DESCRIPTION
Non-urgent follow-up to #219: `--skip-generate` is the flag Prisma 7 silently no-ops (prints help, exits 0) — documented in the brownfield-readiness checklist §4. Today's run worked because this repo is on Prisma 6, but on upgrade the sync step would go green-while-inert and re-plant the outage. Merge with your next batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W18cq3QmWBHN6VZowba7Zn