### PR TITLE
Release: coach date line carries local clock time

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -41,7 +41,10 @@ jobs:
         run: |
           pnpm install --frozen-lockfile
           set -a && source .vercel/.env.production.local && set +a
-          pnpm exec prisma db push --skip-generate
+          # NO --skip-generate: Prisma 7 rejects it by printing help and
+          # exiting 0 — a silent no-op that would re-plant the outage on the
+          # next Prisma upgrade (brownfield-readiness-checklist §4).
+          pnpm exec prisma db push
       - name: Build
         run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
       - name: Deploy to Vercel production

--- a/src/lib/coach/prompt.test.ts
+++ b/src/lib/coach/prompt.test.ts
@@ -107,5 +107,7 @@ describe('prompt', () => {
     const months = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']
     const hasMonth = months.some(month => prompt.includes(month))
     expect(hasMonth).toBe(true)
+    // The user's ask was date AND time — the line carries a local clock too.
+    expect(prompt.split('\n')[0]).toMatch(/^Today is [A-Z][a-z]+, [A-Z][a-z]+ \d{1,2}, \d{1,2}:\d{2} (AM|PM) \(UTC\)\.$/)
   })
 })

--- a/src/lib/coach/prompt.ts
+++ b/src/lib/coach/prompt.ts
@@ -75,7 +75,10 @@ export function buildCoachPrompt(
     const months = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
     const dayName = days[dayOfWeek];
     const monthName = months[month - 1];
-    prompt += `Today is ${dayName}, ${monthName} ${dayOfMonth} (${context.timezone}).\n`;
+    const localTime = new Intl.DateTimeFormat('en-US', {
+      timeZone: context.timezone, hour: 'numeric', minute: '2-digit', hour12: true,
+    }).format(new Date());
+    prompt += `Today is ${dayName}, ${monthName} ${dayOfMonth}, ${localTime} (${context.timezone}).\n`;
   }
 
   prompt += `You are a relationship coach. Your job is to help the user understand and delight their partner, ${context.name}, using only the information provided in the profile records below.\n\n`;


### PR DESCRIPTION
Ships #222 — the coach's context line now includes the local clock time (`Today is Wednesday, August 26, 7:42 PM (America/New_York).`), completing the original 'date AND time' ask. CD's schema-sync step runs harmlessly (no schema change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W18cq3QmWBHN6VZowba7Zn