### PR TITLE
Release: coach date line includes the year

### DIFF
--- a/src/lib/coach/prompt.test.ts
+++ b/src/lib/coach/prompt.test.ts
@@ -108,6 +108,7 @@ describe('prompt', () => {
     const hasMonth = months.some(month => prompt.includes(month))
     expect(hasMonth).toBe(true)
     // The user's ask was date AND time — the line carries a local clock too.
-    expect(prompt.split('\n')[0]).toMatch(/^Today is [A-Z][a-z]+, [A-Z][a-z]+ \d{1,2}, \d{1,2}:\d{2} (AM|PM) \(UTC\)\.$/)
+    expect(prompt.split('\n')[0]).toMatch(/^Today is [A-Z][a-z]+, [A-Z][a-z]+ \d{1,2}, \d{4}, \d{1,2}:\d{2} (AM|PM) \(UTC\)\.$/)
+    expect(prompt.split('\n')[0]).toContain(String(new Date().getUTCFullYear()))
   })
 })

--- a/src/lib/coach/prompt.ts
+++ b/src/lib/coach/prompt.ts
@@ -70,7 +70,7 @@ export function buildCoachPrompt(
   let prompt = '';
 
   if (context.timezone) {
-    const { dayOfWeek, month, dayOfMonth } = localDayParts(new Date(), context.timezone);
+    const { dayOfWeek, month, dayOfMonth, year } = localDayParts(new Date(), context.timezone);
     const days = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
     const months = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
     const dayName = days[dayOfWeek];
@@ -78,7 +78,7 @@ export function buildCoachPrompt(
     const localTime = new Intl.DateTimeFormat('en-US', {
       timeZone: context.timezone, hour: 'numeric', minute: '2-digit', hour12: true,
     }).format(new Date());
-    prompt += `Today is ${dayName}, ${monthName} ${dayOfMonth}, ${localTime} (${context.timezone}).\n`;
+    prompt += `Today is ${dayName}, ${monthName} ${dayOfMonth}, ${year}, ${localTime} (${context.timezone}).\n`;
   }
 
   prompt += `You are a relationship coach. Your job is to help the user understand and delight their partner, ${context.name}, using only the information provided in the profile records below.\n\n`;


### PR DESCRIPTION
Ships #224 — the date line now carries the year, closing the last invented field. Line: `Today is Wednesday, August 26, 2026, 7:20 PM (America/New_York).`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W18cq3QmWBHN6VZowba7Zn